### PR TITLE
Add automated cpplint testing of pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+# https://docs.travis-ci.com/user/languages/cpp/
+language: cpp
+install: pip install cpplint
+script: cpplint .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 # https://docs.travis-ci.com/user/languages/cpp/
 language: cpp
 install: pip install cpplint
-script: cpplint --recursive .
+script: cpplint --recursive . || true  # run without failures for now...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 # https://docs.travis-ci.com/user/languages/cpp/
 language: cpp
 install: pip install cpplint
-script: cpplint .
+script: cpplint --recursive .


### PR DESCRIPTION
Like TheAlgorithms/Python#218 but for C++.  Enables Travis CI to run https://github.com/cpplint/cpplint on every pull request.

The owner of the this repo (@chetanyachopra, @AnupKumarPanwar, ?) would need to go to https://travis-ci.org/TheAlgorithms/C-Plus-Plus and kick off the first build to enable free automated cpplint testing of each pull request.  cpplint will find bugs and code smells.

https://docs.travis-ci.com/user/languages/cpp/