### PR TITLE
fix: attempt to fix GH pages workflow

### DIFF
--- a/.github/workflows/sorting_non_recursive_merge_sort.yml
+++ b/.github/workflows/sorting_non_recursive_merge_sort.yml
@@ -16,6 +16,8 @@ jobs:
       #  with:
       #    github_token: ${{ secrets.GITHUB_TOKEN }}
       #    publish_dir: ./sorting
+      #    external_repository: TheAlgorithms/C-Plus-Plus
+      #    publish_branch: master
       #    enable_jekyll: true
       - run: |
           cd sorting


### PR DESCRIPTION
#### Description of Change

An attempt to fix the issues described at https://github.com/TheAlgorithms/TheAlgorithms.github.io/issues/1. This *should* publish the docs from the `C-Plus-Plus` repo to https://thealgorithms.github.io, but I have no way to test that this works correctly, as you could imagine.

#### Checklist

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTION.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: An attempt to fix the issues described at https://github.com/TheAlgorithms/TheAlgorithms.github.io/issues/1.