### PR TITLE
fix: sqrt_double hangs on x < 1 (#760)

### DIFF
--- a/math/sqrt_double.cpp
+++ b/math/sqrt_double.cpp
@@ -6,6 +6,9 @@ number in O(logn) time,
 with precision fixed */
 
 double Sqrt(double x) {
+    if ( x > 0 && x < 1 ) {
+        return 1/Sqrt(1/x);
+    }
     double l = 0, r = x;
     /* Epsilon is the precision. 
     A great precision is 


### PR DESCRIPTION
#### Handle Sqrt(x), 0 < x < 1
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTION.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Added description of change
- [X] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTION.md#Commit-Guidelines)
- [X] Search previous suggestions before making a new one, as yours may be a duplicate.
- [X] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Existing algo hangs on `Sqrt(0.5)`. Took advantage of equality `Sqrt(x) == 1/Sqrt(1/x)` to avoid evaluating small sqare roots.