### PR TITLE
fix: doubly_linked_list.cpp bug

### DIFF
--- a/data_structure/doubly_linked_list.cpp
+++ b/data_structure/doubly_linked_list.cpp
@@ -61,6 +61,7 @@ void double_linked_list::remove(int x) {
     t->prev->next = t->next;
     t->next->prev = t->prev;
   }
+  delete t;
 }
 
 void double_linked_list::search(int x) {


### PR DESCRIPTION
【memleak】when remove an item , should free the item memory