### PR TITLE
bug fix: large number.h

### DIFF
--- a/math/large_number.h
+++ b/math/large_number.h
@@ -264,7 +264,7 @@ class large_number {
         size_t i;
         uint64_t carry = 0, temp;
         for (i = 0; i < this->num_digits(); i++) {
-            temp = (*this)[i] * n;
+            temp = static_cast<uint64_t>((*this)[i]) * n;
             temp += carry;
             if (temp < 10) {
                 carry = 0;

--- a/math/large_number.h
+++ b/math/large_number.h
@@ -245,7 +245,7 @@ class large_number {
     /**
      * returns i^th digit as an ASCII character
      **/
-    const char digit_char(size_t i) const {
+    char digit_char(size_t i) const {
         return _digits[num_digits() - i - 1] + '0';
     }
 

--- a/math/large_number.h
+++ b/math/large_number.h
@@ -127,7 +127,7 @@ class large_number {
     /**
      * Get number of digits in the number
      **/
-    const size_t num_digits() const { return _digits.size(); }
+    size_t num_digits() const { return _digits.size(); }
 
     /**
      * operator over load to access the

--- a/math/large_number.h
+++ b/math/large_number.h
@@ -53,7 +53,7 @@ class large_number {
     /**< initializer from a string */
     explicit large_number(char const *number_str) {
         for (size_t i = strlen(number_str); i > 0; i--) {
-            unsigned char a = number_str[i - 1] - '0';
+            char a = number_str[i - 1] - '0';
             if (a >= 0 && a <= 9)
                 _digits.push_back(a);
         }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->
First of the fixes for #880 
Addresses the issues with `math/large_number.h` file:
* possible multiplication overflow 
* redundant `const` identifier for functions
* fix signed number check with 0

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [x] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->