### PR TITLE
[bug] disable move error + enforce c++11 for clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 Checks:          '-*,google-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.*,cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-*,openmp-*,performance-*,portability-*,modernize-*,-modernize-use-trailing-*'
-WarningsAsErrors: '*,-google-readability-*,-google-explicit-constructor,-modernize-*,modernize-avoid-c-arrays,-google-explicit-constructor,-performance-move-const-arg,-performance-noexcept-move-constructor,-cppcoreguidelines-init-variables,-cppcoreguidelines-pro-*,-cppcoreguidelines-owning-memory'
+WarningsAsErrors: '*,-google-readability-*,-google-explicit-constructor,-modernize-*,modernize-avoid-c-arrays,-performance-move-const-arg,-performance-noexcept-move-constructor,-cppcoreguidelines-init-variables,-cppcoreguidelines-pro-*,-cppcoreguidelines-owning-memory,-clang-analyzer-cplusplus.Move'
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     '{ BasedOnStyle: Google, UseTab: Never, IndentWidth: 4, TabWidth: 4, AllowShortIfStatementsOnASingleLine: false, IndentCaseLabels: true, ColumnLimit: 80, AccessModifierOffset: -3, AlignConsecutiveMacros: true }'

--- a/.github/workflows/awesome_workflow.yml
+++ b/.github/workflows/awesome_workflow.yml
@@ -122,7 +122,7 @@ jobs:
           if not cpp_files:
             sys.exit(0)
 
-          subprocess.run(["clang-tidy-10", "--fix", "-p=build", *cpp_files, "--"], 
+          subprocess.run(["clang-tidy-10", "--fix", "-p=build", "--extra-args=-std=c++11", *cpp_files, "--"], 
               check=True, text=True, stderr=subprocess.STDOUT)
           # for cpp_file in cpp_files:
           #   subprocess.run(["clang-tidy-10", "--fix", "-p=build", cpp_file, "--"], 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->
Disabled `clang-analyzer-cplusplus.Move` error to warning. 
See https://clang.llvm.org/extra/clang-tidy/checks/bugprone-use-after-move.html

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [ ] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [ ] Relevant documentation/comments is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [ ] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/948"><img src="https://gitpod.io/api/apps/github/pbs/github.com/kvedala/C-Plus-Plus.git/4e12f03c6cbfa42d7f77d06edd08e39cfb901f4b.svg" /></a>

