### PR TITLE
fix: Integer overflow of least_common_multiple.

### DIFF
--- a/math/least_common_multiple.cpp
+++ b/math/least_common_multiple.cpp
@@ -40,7 +40,9 @@ unsigned int gcd(unsigned int x, unsigned int y) {
  * @params integer x and y whose lcm we want to find.
  * @return lcm of x and y using the relation x * y = gcd(x, y) * lcm(x, y)
  */
-unsigned int lcm(unsigned int x, unsigned int y) { return x * y / gcd(x, y); }
+unsigned int lcm(unsigned int x, unsigned int y) {
+  return x / gcd(x, y) * y;
+}
 
 /**
  * Function for testing the lcm() functions with some assert statements.
@@ -58,6 +60,15 @@ void tests() {
                   "result.\n",
             lcm(2, 3) == 6));
     std::cout << "Second assertion passes: LCM of 2 and 3 is " << lcm(2, 3)
+              << std::endl;
+
+    // Testing an integer overflow.
+    // The algorithm should work as long as the result fits into integer.
+    assert(((void)"LCM of 987654321 and 987654321 is 987654321 but lcm function"
+                  " gives a different result.\n",
+            lcm(987654321, 987654321) == 987654321));
+    std::cout << "Third assertion passes: LCM of 987654321 and 987654321 is "
+              << lcm(987654321, 987654321)
               << std::endl;
 }
 

--- a/math/least_common_multiple.cpp
+++ b/math/least_common_multiple.cpp
@@ -26,12 +26,12 @@ unsigned int gcd(unsigned int x, unsigned int y) {
     if (x > y) {
         // The following is valid because we have checked whether y == 0
 
-        int temp = x / y;
+        unsigned int temp = x / y;
         return gcd(y, x - temp * y);
     }
     // Again the following is valid because we have checked whether x == 0
 
-    int temp = y / x;
+    unsigned int temp = y / x;
     return gcd(x, y - temp * x);
 }
 


### PR DESCRIPTION
#### Description of Change
Improving the least common multiple algorithm which unnecessarily caused an integer overflow since the two numbers were multiplied first and only then divided by the greatest common divisor. Using a common trick to first divide the first number with the common divisor and only multiply later. Adding a unit test to test this functionality.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Added description of change
- [X] Added tests and example, test must pass
- [X] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [X] Relevant documentation/comments is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [X] Search previous suggestions before making a new one, as yours may be a duplicate.
- [X] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/970"><img src="https://gitpod.io/api/apps/github/pbs/github.com/fhlasek/C-Plus-Plus.git/47974f0a72b0fa87ba02701b1374ab2f86c858dd.svg" /></a>

