### PR TITLE
Revert "[bug] updated free glut checksum"

### DIFF
--- a/graphics/CMakeLists.txt
+++ b/graphics/CMakeLists.txt
@@ -7,7 +7,7 @@ if(OpenGL_FOUND)
         ExternalProject_Add (
             FREEGLUT-PRJ
             URL https://sourceforge.net/projects/freeglut/files/freeglut/3.2.1/freeglut-3.2.1.tar.gz
-            URL_MD5 afd33cb888461aae3bfd05b80c9e42a8
+            URL_MD5 cd5c670c1086358598a6d4a9d166949d
             CMAKE_GENERATOR ${CMAKE_GENERATOR}
             CMAKE_GENERATOR_TOOLSET ${CMAKE_GENERATOR_TOOLSET}
             CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}


### PR DESCRIPTION
Reverts TheAlgorithms/C-Plus-Plus#976

The checksum fail was due to Sourceforge being down.

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/977"><img src="https://gitpod.io/api/apps/github/pbs/github.com/TheAlgorithms/C-Plus-Plus.git/4c597a46becd3c2fce76c1f68ec3df6c29cdbd3c.svg" /></a>

