### PR TITLE
docs: Update clang-format instructions in CONTRIBUTING.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,19 +152,26 @@ Common prefixes:
 ### Pull Requests
 - Checkout our [pull request template](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/.github/pull_request_template.md)
 
-#### cpplint
-To see if [__cpplint__](https://github.com/cpplint/cpplint) is already installed, do:
-* `cpplint --version`  # currently returns "cpplint 1.4.4"
-If cpplint is ___not___ installed then do:
-* `python3 -m pip install cpplint`  # If that does not work then try...
-* `py -m pip install cpplint`  # If that does not work then try...
-* `pip install cpplint`
-Once cpplint is installed, test your file(s) with:
-* `cpplint --filter=-legal my_file.cpp my_other_file.cpp`  # Fix any issues and try again.
+#### Building Locally
+Before submitting a pull request, build the code locally.
+That may save you time waiting for the CI (continuous intgration) to run.
+* `cmake -B build -S .`
 
-The [__clang-format__](https://clang.llvm.org/docs/ClangFormat.html) tool can fix whitespace related _cpplint_ issues.
-* On Macs only: `brew install clang-format`  # Only needs to be installed once.
-* All platforms: `clang-format -i -style="file" my_file.cpp`
+#### Static Code Analyzer
+We use [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) as a static code analyzer with a configuration in [.clang-tidy](.clang-tidy).
+* `clang-tidy --fix --quiet -p build subfolder/file_to_check.cpp --`
+
+#### Code Formatter
+[__clang-format__](https://clang.llvm.org/docs/ClangFormat.html) is used for code forrmating.
+* Installation (Mac only): `brew install clang-format`  # Only needs to be installed once.
+* Running (all platforms): `clang-format -i -style="file" my_file.cpp`
+
+#### GitHub Actions
+Enable GitHub Actions on your fork of the repository.
+After enabling it will execute `clang-tidy` and `clang-format` after every a push (not a commit).
+The result can create another commit if the actions made any changes on your behalf.
+Hence, it is better to wait and check the results of GitHub Actions after every push.
+Run `git pull` in your local clone if these actions made many changes in order to avoid merge conflicts.
 
 Most importantly,
 - Happy coding!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,6 @@ Common prefixes:
 
 #### Building Locally
 Before submitting a pull request, build the code locally or using the convenient [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus) service.
-That may save you time waiting for the CI (continuous intgration) to run.
 ```
 cmake -B build -S .
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,11 +155,13 @@ Common prefixes:
 #### Building Locally
 Before submitting a pull request, build the code locally.
 That may save you time waiting for the CI (continuous intgration) to run.
-* `cmake -B build -S .`
+```
+cmake -B build -S .
+```
 
 #### Static Code Analyzer
 We use [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) as a static code analyzer with a configuration in [.clang-tidy](.clang-tidy).
-```shell
+```
 clang-tidy --fix --quiet -p build subfolder/file_to_check.cpp --
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ Common prefixes:
 - Checkout our [pull request template](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/.github/pull_request_template.md)
 
 #### Building Locally
-Before submitting a pull request, build the code locally.
+Before submitting a pull request, build the code locally or using the convenient [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus) service.
 That may save you time waiting for the CI (continuous intgration) to run.
 ```
 cmake -B build -S .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,9 @@ That may save you time waiting for the CI (continuous intgration) to run.
 
 #### Static Code Analyzer
 We use [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) as a static code analyzer with a configuration in [.clang-tidy](.clang-tidy).
-> `clang-tidy --fix --quiet -p build subfolder/file_to_check.cpp --`
+```shell
+clang-tidy --fix --quiet -p build subfolder/file_to_check.cpp --
+```
 
 #### Code Formatter
 [__clang-format__](https://clang.llvm.org/docs/ClangFormat.html) is used for code forrmating.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ That may save you time waiting for the CI (continuous intgration) to run.
 
 #### Static Code Analyzer
 We use [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) as a static code analyzer with a configuration in [.clang-tidy](.clang-tidy).
-* `clang-tidy --fix --quiet -p build subfolder/file_to_check.cpp --`
+> `clang-tidy --fix --quiet -p build subfolder/file_to_check.cpp --`
 
 #### Code Formatter
 [__clang-format__](https://clang.llvm.org/docs/ClangFormat.html) is used for code forrmating.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,11 @@ clang-tidy --fix --quiet -p build subfolder/file_to_check.cpp --
 
 #### Code Formatter
 [__clang-format__](https://clang.llvm.org/docs/ClangFormat.html) is used for code forrmating.
-* Installation (Mac only): `brew install clang-format`  # Only needs to be installed once.
+* Installation (Only needs to be installed once.)
+  * Mac (using home-brew): `brew install clang-format`
+  * Mac (using macports): `sudo port install clang-10 +analyzer`
+  * Windows (MSYS2 64-bit): `pacman -S mingw-w64-x86_64-clang-tools-extra`
+  * Linux (Debian): `sudo apt-get install clang-format-10 clang-tidy-10`
 * Running (all platforms): `clang-format -i -style="file" my_file.cpp`
 
 #### GitHub Actions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ Once cpplint is installed, test your file(s) with:
 
 The [__clang-format__](https://clang.llvm.org/docs/ClangFormat.html) tool can fix whitespace related _cpplint_ issues.
 * On Macs only: `brew install clang-format`  # Only needs to be installed once.
-* All platforms: `clang-format -i -style="{IndentWidth: 4}" my_file.cpp`
+* All platforms: `clang-format -i -style="file" my_file.cpp`
 
 Most importantly,
 - Happy coding!


### PR DESCRIPTION
#### Description of Change
Aligning the instructions in [CONTRIBUTING.md](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md) to use the pre-defined style from [.clang-format](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/.clang-format) instroduced by #1052.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Added description of change
- [X] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [X] Added tests and example, test must pass
- [X] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [X] Relevant documentation/comments is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [X] Search previous suggestions before making a new one, as yours may be a duplicate.
- [X] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1053"><img src="https://gitpod.io/api/apps/github/pbs/github.com/fhlasek/C-Plus-Plus.git/594a3afc59a184d73f2c2e89737e13698895169e.svg" /></a>

