### PR TITLE
fix: Removed .vscode/* 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-     "C_Cpp.clang_format_style": "{ BasedOnStyle: Google, UseTab: Never, IndentWidth: 4, TabWidth: 4, AllowShortIfStatementsOnASingleLine: false, IndentCaseLabels: true, ColumnLimit: 80, AccessModifierOffset: -3, AlignConsecutiveMacros: true }",
-     "editor.formatOnSave": true,
-     "editor.formatOnType": true,
-     "editor.formatOnPaste": true
-}


### PR DESCRIPTION


#### Description of Change

Removed the folder ```.vscode```.  I think it was added by mistake. Probably because folder created by VSCode editor was tracked under the version control. 

As it is contributor's responsibility to not include such files in PR I have not updated the ```.gitignore```. 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [x] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1153"><img src="https://gitpod.io/api/apps/github/pbs/github.com/imdeep2905/C-Plus-Plus.git/6e06750a955e30b42793bd539c892b9d1f18128c.svg" /></a>

