### PR TITLE
optimized space-complexity from O(m*n) to O(n) in edit-distanceprogram

### DIFF
--- a/dynamic_programming/edit_distance.cpp
+++ b/dynamic_programming/edit_distance.cpp
@@ -1,3 +1,4 @@
+
 /* Given two strings str1 & str2
  * and below operations that can
  * be performed on str1. Find
@@ -73,6 +74,44 @@ int editDistDP(string str1, string str2, int m, int n) {
 
     return dp[m][n];
 }
+/* A DP based program
+   O(n)
+   We will store values of present and previous index
+   instead of storing O(m x n)
+*/
+int editDistDP_in_O_n_space(string str1, string str2, int m, int n) {
+
+    int pre[n + 1]; //stores the value for previous index
+
+    for (int i = 0; i <= m; i++) {
+        int cur[n+1]; //stores the value for current index
+        for (int j = 0; j <= n; j++) {
+            // If str1 empty. Then add all of str2
+            if (i == 0)
+                cur[j] = j;
+
+            // If str2 empty. Then add all of str1
+            else if (j == 0)
+                cur[j] = i;
+
+            // If character same. Recur for remaining
+            else if (str1[i - 1] == str2[j - 1])
+                cur[j] = pre[j - 1];
+
+            else
+                cur[j] = 1 + min(cur[j - 1],     // Insert
+                                   pre[j],     // Remove
+                                   pre[j - 1]  // Replace
+                               );
+        }
+        for(int j=0;j<=n;j++)
+        {
+            pre[j]=cur[j];
+        }
+    }
+
+    return pre[n];
+}
 
 int main() {
     string str1 = "sunday";
@@ -80,6 +119,7 @@ int main() {
 
     cout << editDist(str1, str2, str1.length(), str2.length()) << endl;
     cout << editDistDP(str1, str2, str1.length(), str2.length()) << endl;
+    cout << editDistDP_in_O_n_space(str1, str2, str1.length(), str2.length()) << endl;
 
     return 0;
 }

--- a/dynamic_programming/edit_distance.cpp
+++ b/dynamic_programming/edit_distance.cpp
@@ -14,16 +14,17 @@
 
 #include <iostream>
 #include <string>
-using namespace std;
+#include <vector>
 
-int min(int x, int y, int z) { return min(min(x, y), z); }
+
+int min(int x, int y, int z) { return std::min(std::min(x, y), z); }
 
 /* A Naive recursive C++ program to find
  * minimum number of operations to convert
  * str1 to str2.
  * O(3^m)
  */
-int editDist(string str1, string str2, int m, int n) {
+int editDist(const std::string &str1,const std::string &str2, int m, int n) {
     if (m == 0)
         return n;
     if (n == 0)
@@ -45,9 +46,9 @@ int editDist(string str1, string str2, int m, int n) {
 /* A DP based program
  * O(m x n)
  */
-int editDistDP(string str1, string str2, int m, int n) {
+int editDistDP(const std::string &str1,const std::string &str2, int m, int n) {
     // Create Table for SubProblems
-    int dp[m + 1][n + 1];
+    std::vector<std::vector<int>>dp(m+1,std::vector<int>(n+1));
 
     // Fill d[][] in bottom up manner
     for (int i = 0; i <= m; i++) {
@@ -79,12 +80,12 @@ int editDistDP(string str1, string str2, int m, int n) {
    We will store values of present and previous index
    instead of storing O(m x n)
 */
-int editDistDP_in_O_n_space(string str1, string str2, int m, int n) {
+int editDistDP_in_O_n_space(const std::string &str1,const std::string &str2, int m, int n) {
 
-    int pre[n + 1]; //stores the value for previous index
+    std::vector<int>pre(n + 1); //stores the value for previous index
 
     for (int i = 0; i <= m; i++) {
-        int cur[n+1]; //stores the value for current index
+        std::vector<int>cur(n + 1); //stores the value for current index
         for (int j = 0; j <= n; j++) {
             // If str1 empty. Then add all of str2
             if (i == 0)
@@ -114,12 +115,12 @@ int editDistDP_in_O_n_space(string str1, string str2, int m, int n) {
 }
 
 int main() {
-    string str1 = "sunday";
-    string str2 = "saturday";
+    std::string str1 = "sunday";
+    std::string str2 = "saturday";
 
-    cout << editDist(str1, str2, str1.length(), str2.length()) << endl;
-    cout << editDistDP(str1, str2, str1.length(), str2.length()) << endl;
-    cout << editDistDP_in_O_n_space(str1, str2, str1.length(), str2.length()) << endl;
+    std::cout << editDist(str1, str2, str1.length(), str2.length()) << std::endl;
+    std::cout << editDistDP(str1, str2, str1.length(), str2.length()) << std::endl;
+    std::cout << editDistDP_in_O_n_space(str1, str2, str1.length(), str2.length()) <<std::endl;
 
     return 0;
 }

--- a/dynamic_programming/edit_distance.cpp
+++ b/dynamic_programming/edit_distance.cpp
@@ -44,7 +44,8 @@ int editDist(const std::string &str1,const std::string &str2, int m, int n) {
 }
 
 /* A DP based program
- * O(m x n)
+ * Time Complexity:O(m x n)
+ * Space Complexity: O(m x n)
  */
 int editDistDP(const std::string &str1,const std::string &str2, int m, int n) {
     // Create Table for SubProblems
@@ -77,9 +78,8 @@ int editDistDP(const std::string &str1,const std::string &str2, int m, int n) {
 }
 
 /* A DP based program
-   O(n)
-   We will store values of present and previous index
-   instead of storing O(m x n)
+ * Time Complexity: O(m x n)
+ * Space Complexity: O(n) 
  */
 
 /* In the above DP approach,
@@ -96,6 +96,7 @@ int editDistDP(const std::string &str1,const std::string &str2, int m, int n) {
  * thus we will copy the cur vector to pre vector
  * and move to next index
  */ 
+
 int editDistDP_in_O_n_space(const std::string &str1,const std::string &str2, int m, int n) {
 
     std::vector<int>pre(n + 1); //stores the dp value for previous index

--- a/dynamic_programming/edit_distance.cpp
+++ b/dynamic_programming/edit_distance.cpp
@@ -75,6 +75,20 @@ int editDistDP(const std::string &str1,const std::string &str2, int m, int n) {
 
     return dp[m][n];
 }
+/*In the above DP approach,
+ *for particular index i we require
+ *dp[i-1][j] and dp[i-1][j-1] values.
+ *Thus dp values before i-1 i.e 
+ *dp[i-2][j],dp[i-3][j]...
+ *values are no use to us.
+ *Therefore instead of storing m*n table
+ *we only store values of dp[i-1][0],dp[i-1][1] ....dp[i-1[m] in 1D vector.
+ *After traversing for particular index i
+ *current dp values become previous dp values for index i+1
+ *thus we copy the cur vector to pre vector
+ */ 
+ 
+ 
 /* A DP based program
    O(n)
    We will store values of present and previous index
@@ -82,10 +96,10 @@ int editDistDP(const std::string &str1,const std::string &str2, int m, int n) {
 */
 int editDistDP_in_O_n_space(const std::string &str1,const std::string &str2, int m, int n) {
 
-    std::vector<int>pre(n + 1); //stores the value for previous index
+    std::vector<int>pre(n + 1); //stores the dp value for previous index
 
     for (int i = 0; i <= m; i++) {
-        std::vector<int>cur(n + 1); //stores the value for current index
+        std::vector<int>cur(n + 1); //stores the dp value for current index
         for (int j = 0; j <= n; j++) {
             // If str1 empty. Then add all of str2
             if (i == 0)
@@ -105,10 +119,12 @@ int editDistDP_in_O_n_space(const std::string &str1,const std::string &str2, int
                                    pre[j - 1]  // Replace
                                );
         }
+        //now for next index i.e (i+1) we require dp values of ith index
+        //so now cur becomes pre
         for(int j=0;j<=n;j++)
-        {
-            pre[j]=cur[j];
-        }
+         {
+            pre[j]=cur[j];   //copying cur values to pre
+         }
     }
 
     return pre[n];

--- a/dynamic_programming/edit_distance.cpp
+++ b/dynamic_programming/edit_distance.cpp
@@ -75,25 +75,27 @@ int editDistDP(const std::string &str1,const std::string &str2, int m, int n) {
 
     return dp[m][n];
 }
-/*In the above DP approach,
- *for particular index i we require
- *dp[i-1][j] and dp[i-1][j-1] values.
- *Thus dp values before i-1 i.e 
- *dp[i-2][j],dp[i-3][j]...
- *values are no use to us.
- *Therefore instead of storing m*n table
- *we only store values of dp[i-1][0],dp[i-1][1] ....dp[i-1[m] in 1D vector.
- *After traversing for particular index i
- *current dp values become previous dp values for index i+1
- *thus we copy the cur vector to pre vector
- */ 
- 
- 
+
 /* A DP based program
    O(n)
    We will store values of present and previous index
    instead of storing O(m x n)
-*/
+ */
+
+/* In the above DP approach,
+ * for particular index i we require
+ * dp[i-1][j] and dp[i-1][j-1] values.
+ * Thus dp values before i-1 i.e 
+ * dp[i-2][j],dp[i-3][j]...
+ * values are of no use to us.
+ * Therefore instead of storing m*n table
+ * we will only store values of 
+ * dp[i-1][0],dp[i-1][1] ....dp[i-1[m] in 1D vector.
+ * After traversing for particular index i
+ * current dp values become previous dp values for index i+1
+ * thus we will copy the cur vector to pre vector
+ * and move to next index
+ */ 
 int editDistDP_in_O_n_space(const std::string &str1,const std::string &str2, int m, int n) {
 
     std::vector<int>pre(n + 1); //stores the dp value for previous index


### PR DESCRIPTION
#### Description of Change
<
**Optimized space-complexity from O(m*n) to O(n) in edit-distance program**
I have added the function editDistDP_in_O_n_space in edit-distance program under dynamic-programming section. This function will use O(n) space complexity instead of O(m*n) space complexity to calculate the answer.
>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)

- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <Reduced the space complexity from O(m*n) to O(n)>

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1257"><img src="https://gitpod.io/api/apps/github/pbs/github.com/arpanbhatt/C-Plus-Plus.git/7bd514590a30a9e602a02068ed1d9fa687efeb0e.svg" /></a>

