### PR TITLE
fix: remove `using namespace std` in greedy_algorithms/kruskals_minimum_spanning_tree.cpp

### DIFF
--- a/greedy_algorithms/kruskals_minimum_spanning_tree.cpp
+++ b/greedy_algorithms/kruskals_minimum_spanning_tree.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-using namespace std;
+
 
 #define V 6
 #define INFINITY 99999
@@ -21,7 +21,7 @@ void findMinimumEdge() {
                 minIndex = j;
             }
         }
-        cout << i << "  -  " << minIndex << "\t" << graph[i][minIndex] << "\n";
+        std::cout << i << "  -  " << minIndex << "\t" << graph[i][minIndex] << std::endl;
     }
 }
 

--- a/greedy_algorithms/kruskals_minimum_spanning_tree.cpp
+++ b/greedy_algorithms/kruskals_minimum_spanning_tree.cpp
@@ -1,10 +1,10 @@
 #include <iostream>
+#include <vector>
 
+constexpr int V = 6;
+constexpr int INFINITY = 99999;
 
-#define V 6
-#define INFINITY 99999
-
-int graph[V][V] = {{0, 4, 1, 4, INFINITY, INFINITY},
+std::vector< std::vector< int > >graph {{0, 4, 1, 4, INFINITY, INFINITY},
                    {4, 0, 3, 8, 3, INFINITY},
                    {1, 3, 0, INFINITY, 1, INFINITY},
                    {4, 8, INFINITY, 0, 5, 7},

--- a/greedy_algorithms/kruskals_minimum_spanning_tree.cpp
+++ b/greedy_algorithms/kruskals_minimum_spanning_tree.cpp
@@ -1,21 +1,11 @@
 #include <iostream>
-#include <vector>
+#include <array>
 
-constexpr int V = 6;
-constexpr int INFINITY = 99999;
-
-std::vector< std::vector< int > >graph {{0, 4, 1, 4, INFINITY, INFINITY},
-                   {4, 0, 3, 8, 3, INFINITY},
-                   {1, 3, 0, INFINITY, 1, INFINITY},
-                   {4, 8, INFINITY, 0, 5, 7},
-                   {INFINITY, 3, 1, 5, 0, INFINITY},
-                   {INFINITY, INFINITY, INFINITY, 7, INFINITY, 0}};
-
-void findMinimumEdge() {
-    for (int i = 0; i < V; i++) {
+void findMinimumEdge(int INFINITY, std::array< std::array< int ,6 >,6 > graph) {
+    for (int i = 0; i < graph.size(); i++) {
         int min = INFINITY;
         int minIndex = 0;
-        for (int j = 0; j < V; j++) {
+        for (int j = 0; j <  graph.size(); j++) {
             if (graph[i][j] != 0 && graph[i][j] < min) {
                 min = graph[i][j];
                 minIndex = j;
@@ -26,6 +16,15 @@ void findMinimumEdge() {
 }
 
 int main() {
-    findMinimumEdge();
+    constexpr int INFINITY = 99999;
+    std::array< std::array< int ,6 >,6 >graph
+        {0, 4, 1, 4, INFINITY, INFINITY,
+         4, 0, 3, 8, 3, INFINITY,
+         1, 3, 0, INFINITY, 1, INFINITY,
+         4, 8, INFINITY, 0, 5, 7,
+         INFINITY, 3, 1, 5, 0, INFINITY,
+         INFINITY, INFINITY, INFINITY, 7, INFINITY, 0};
+
+    findMinimumEdge(INFINITY,graph);
     return 0;
 }


### PR DESCRIPTION
 using namespace std is a bad practice

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1264"><img src="https://gitpod.io/api/apps/github/pbs/github.com/x0rld/C-Plus-Plus.git/38437e09b012036f0a8d09dcb14c4be745cba2e1.svg" /></a>

