### PR TITLE
[fix/docs]: Memory leakage caused by using `new` operator & refactoring/documentation

### DIFF
--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -10,30 +10,31 @@
 #define MAX_SIZE 10
 
 class Queue_Array {
-    int front;
-    int rear;
-
- public:
-    Queue_Array() {
-        front = -1;
-        rear = -1;
-        arr.resize(MAX_SIZE);
-    }
-
-    std::vector<int> arr;
+public:
+    Queue_Array();
     void enqueue(int);
     int dequeue();
-    void display();
+    void display() const;
+private:
+    int front;
+    int rear;
+    std::vector<int> arr;
 };
 
-void Queue_Array::enqueue(int ele) {
+Queue_Array::Queue_Array() {
+    front = -1;
+    rear = -1;
+    arr.resize(MAX_SIZE);
+}
+
+void Queue_Array::enqueue(const int ele) {
     if (rear == arr.size() - 1) {
         std::cout << "\nStack is full";
     } else if (front == -1 && rear == -1) {
         front = rear = 0;
         arr.at(rear) = ele;
     } else if (rear < arr.size()) {
-        rear++;
+        ++rear;
         arr.at(rear) = ele;
     }
 }
@@ -53,11 +54,11 @@ int Queue_Array::dequeue() {
     return d;
 }
 
-void Queue_Array::display() {
+void Queue_Array::display() const {
     if (front == -1) {
         std::cout << "\nStack is empty";
     } else {
-        for (int i = front; i <= rear; i++) std::cout << arr.at(i) << " ";
+        for (int i{front}; i <= rear; ++i) std::cout << arr.at(i) << " ";
     }
 }
 

--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -17,7 +17,7 @@
  * @author [Farbod Ahmadian](https://github.com/farbodahm)
  */
 #include <iostream> /// for io operations
-#include <vector>   /// for std::vector
+#include <array>   /// for std::array
 
 constexpr uint16_t max_size{10}; ///< Maximum size of the queue
 
@@ -39,37 +39,29 @@ namespace queue_using_array {
  */
 class Queue_Array {
 public:
-    Queue_Array();                ///< Set maximum number of data 
-    void enqueue(const int8_t&);  ///< Add element to the first of the queue
+    void enqueue(const int16_t&);  ///< Add element to the first of the queue
     int dequeue();                ///< Delete element from back of the queue
     void display() const;         ///< Show all saved data
 private:
     int8_t front{-1};             ///< Index of head of the array
     int8_t rear{-1};              ///< Index of tail of the array
-    std::vector<int8_t> arr{};    ///< All stored data
+    std::array<int16_t, max_size> arr;    ///< All stored data
 };
-
-
-/**
-* @brief Queue_Array constructor. Initializes the maximum number of data than can be saved.
-*/
-Queue_Array::Queue_Array() {
-    arr.resize(max_size);
-}
 
 /**
  * @brief Adds new element to the end of the queue
  * @param ele to be added to the end of the queue
  */
-void Queue_Array::enqueue(const int8_t& ele) {
+void Queue_Array::enqueue(const int16_t& ele ) {
     if (rear == arr.size() - 1) {
         std::cout << "\nStack is full";
     } else if (front == -1 && rear == -1) {
-        front = rear = 0;
-        arr.at(rear) = ele;
+        front = 0;
+        rear = 0;
+        arr[rear] = ele;
     } else if (rear < arr.size()) {
         ++rear;
-        arr.at(rear) = ele;
+        arr[rear] = ele;
     }
 }
 
@@ -99,7 +91,7 @@ void Queue_Array::display() const {
     if (front == -1) {
         std::cout << "\nStack is empty";
     } else {
-        for (int8_t i{front}; i <= rear; ++i) std::cout << arr.at(i) << " ";
+        for (int16_t i{front}; i <= rear; ++i) std::cout << arr.at(i) << " ";
     }
 }
 

--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -1,14 +1,37 @@
-/*
-    Write a program to implement Linear Queue using array.
-    Functions to implement
-        Enqueue (Insertion)
-        Dequeue (Deletion)
-*/
+/**
+ * @file
+ * @brief Implementation of Linear Queue using array.
+ * @details
+ * The Linear Queue is a data structure used for holding a sequence of
+ * values, which can be added to the end line (enqueue), removed from
+ * head of line (dequeue) and displayed.
+ * ### Algorithm
+ * Values can be added by increasing the `rear` variable by 1 (which points to 
+ * the end of the array), then assigning new value to `rear`'s element of the array.
+ * 
+ * Values can be removed by increasing the `front` variable by 1 (which points to 
+ * the first of the array), so it cannot reached any more.
+ */
 #include <iostream>
 #include <vector>
 
 constexpr uint8_t max_size{10};
 
+/**
+ * @namespace data_structures
+ * @brief Data Structures algorithms
+ */
+namespace data_structures {
+
+/**
+ * @namespace linked_list
+ * @brief Functions for singly linked list algorithm
+ */
+namespace linked_list {
+
+/**
+ * Queue_Array class containing the main data and also index of head and tail of the array.
+ */
 class Queue_Array {
 public:
     Queue_Array();
@@ -16,15 +39,23 @@ public:
     int dequeue();
     void display() const;
 private:
-    int8_t front{-1};
-    int8_t rear{-1};
-    std::vector<int8_t> arr{};
+    int8_t front{-1};           ///< Index of head of the array
+    int8_t rear{-1};            ///< Index of tail of the array
+    std::vector<int8_t> arr{};  ///< All stored data
 };
 
+
+/**
+* Queue_Array constructor. Initializes the maximum number of data than can be saved.
+*/
 Queue_Array::Queue_Array() {
     arr.resize(max_size);
 }
 
+/**
+ * function adds new element to the end of the queue
+ * @param ele to be added to the end of the queue
+ */
 void Queue_Array::enqueue(const int8_t& ele) {
     if (rear == arr.size() - 1) {
         std::cout << "\nStack is full";
@@ -37,6 +68,10 @@ void Queue_Array::enqueue(const int8_t& ele) {
     }
 }
 
+/**
+ * function removes the element at the first of the queue
+ * @returns data that is deleted if queue is not empty
+ */
 int Queue_Array::dequeue() {
     int8_t d{0};
     if (front == -1) {
@@ -52,6 +87,9 @@ int Queue_Array::dequeue() {
     return d;
 }
 
+/**
+ * function shows all elements in the queue
+ */
 void Queue_Array::display() const {
     if (front == -1) {
         std::cout << "\nStack is empty";
@@ -60,10 +98,19 @@ void Queue_Array::display() const {
     }
 }
 
+}  // namespace linked_list
+}  // namespace data_structures
+
+
+/**
+ * Main function:
+ * Allows the user add and delete values from the queue.
+ * Also allows user to display values in the queue.
+ * @returns 0 on exit
+ */
 int main() {
     int op{0}, data{0};
-
-    Queue_Array ob;
+    data_structures::linked_list::Queue_Array ob;
 
     std::cout << "\n1. enqueue(Insertion) ";
     std::cout << "\n2. dequeue(Deletion)";

--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -1,6 +1,7 @@
 /**
  * @file
- * @brief Implementation of Linear Queue using array.
+ * @brief Implementation of Linear [Queue using array]
+ * (https://www.geeksforgeeks.org/array-implementation-of-queue-simple/).
  * @details
  * The Linear Queue is a data structure used for holding a sequence of
  * values, which can be added to the end line (enqueue), removed from
@@ -11,26 +12,30 @@
  * 
  * Values can be removed by increasing the `front` variable by 1 (which points to 
  * the first of the array), so it cannot reached any more.
+ * 
+ * @author [Pooja](https://github.com/pooja-git11)
+ * @author [Farbod Ahmadian](https://github.com/farbodahm)
  */
-#include <iostream>
-#include <vector>
+#include <iostream> /// for io operations
+#include <vector>   /// for std::vector
 
 constexpr uint8_t max_size{10};
 
 /**
  * @namespace data_structures
- * @brief Data Structures algorithms
+ * @brief Algorithms with data structures
  */
 namespace data_structures {
 
 /**
- * @namespace linked_list
- * @brief Functions for singly linked list algorithm
+ * @namespace queue_using_array
+ * @brief Functions for [Queue using Array]
+ * (https://www.geeksforgeeks.org/array-implementation-of-queue-simple/) implementation.
  */
-namespace linked_list {
+namespace queue_using_array {
 
 /**
- * Queue_Array class containing the main data and also index of head and tail of the array.
+ * @brief Queue_Array class containing the main data and also index of head and tail of the array.
  */
 class Queue_Array {
 public:
@@ -110,7 +115,7 @@ void Queue_Array::display() const {
  */
 int main() {
     int op{0}, data{0};
-    data_structures::linked_list::Queue_Array ob;
+    data_structures::queue_using_array::Queue_Array ob;
 
     std::cout << "\n1. enqueue(Insertion) ";
     std::cout << "\n2. dequeue(Deletion)";

--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -1,41 +1,40 @@
 /*
     Write a program to implement Linear Queue using array.
-
     Functions to implement
         Enqueue (Insertion)
         Dequeue (Deletion)
-
 */
 #include <iostream>
+#include <vector>
 
-#define MAXSIZE 10
+#define MAX_SIZE 10
 
 class Queue_Array {
     int front;
     int rear;
-    int size;
 
  public:
     Queue_Array() {
         front = -1;
         rear = -1;
-        size = MAXSIZE;
+        arr.resize(MAX_SIZE);
     }
-    int *arr = new int[size];
+
+    std::vector<int> arr;
     void enqueue(int);
     int dequeue();
     void display();
 };
 
 void Queue_Array::enqueue(int ele) {
-    if (rear == size - 1) {
+    if (rear == arr.size() - 1) {
         std::cout << "\nStack is full";
     } else if (front == -1 && rear == -1) {
         front = rear = 0;
-        arr[rear] = ele;
-    } else if (rear < size) {
+        arr.at(rear) = ele;
+    } else if (rear < arr.size()) {
         rear++;
-        arr[rear] = ele;
+        arr.at(rear) = ele;
     }
 }
 
@@ -45,10 +44,10 @@ int Queue_Array::dequeue() {
         std::cout << "\nstack is empty ";
         return 0;
     } else if (front == rear) {
-        d = arr[front];
+        d = arr.at(front);
         front = rear = -1;
     } else {
-        d = arr[front++];
+        d = arr.at(front++);
     }
 
     return d;
@@ -58,7 +57,7 @@ void Queue_Array::display() {
     if (front == -1) {
         std::cout << "\nStack is empty";
     } else {
-        for (int i = front; i <= rear; i++) std::cout << arr[i] << " ";
+        for (int i = front; i <= rear; i++) std::cout << arr.at(i) << " ";
     }
 }
 

--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -87,4 +87,6 @@ int main() {
             std::cout << "\nWrong choice ";
         }
     }
+
+    return 0;
 }

--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -39,26 +39,26 @@ namespace queue_using_array {
  */
 class Queue_Array {
 public:
-    Queue_Array();
-    void enqueue(const int8_t&);
-    int dequeue();
-    void display() const;
+    Queue_Array();                ///< Set maximum number of data 
+    void enqueue(const int8_t&);  ///< Add element to the first of the queue
+    int dequeue();                ///< Delete element from back of the queue
+    void display() const;         ///< Show all saved data
 private:
-    int8_t front{-1};           ///< Index of head of the array
-    int8_t rear{-1};            ///< Index of tail of the array
-    std::vector<int8_t> arr{};  ///< All stored data
+    int8_t front{-1};             ///< Index of head of the array
+    int8_t rear{-1};              ///< Index of tail of the array
+    std::vector<int8_t> arr{};    ///< All stored data
 };
 
 
 /**
-* Queue_Array constructor. Initializes the maximum number of data than can be saved.
+* @brief Queue_Array constructor. Initializes the maximum number of data than can be saved.
 */
 Queue_Array::Queue_Array() {
     arr.resize(max_size);
 }
 
 /**
- * function adds new element to the end of the queue
+ * @brief Adds new element to the end of the queue
  * @param ele to be added to the end of the queue
  */
 void Queue_Array::enqueue(const int8_t& ele) {
@@ -74,7 +74,7 @@ void Queue_Array::enqueue(const int8_t& ele) {
 }
 
 /**
- * function removes the element at the first of the queue
+ * @brief Remove element that is located at the first of the queue
  * @returns data that is deleted if queue is not empty
  */
 int Queue_Array::dequeue() {
@@ -93,7 +93,7 @@ int Queue_Array::dequeue() {
 }
 
 /**
- * function shows all elements in the queue
+ * @brief Utility function to show all elements in the queue
  */
 void Queue_Array::display() const {
     if (front == -1) {
@@ -103,13 +103,14 @@ void Queue_Array::display() const {
     }
 }
 
-}  // namespace linked_list
+}  // namespace queue_using_array
 }  // namespace data_structures
 
 
 /**
- * Main function:
- * Allows the user add and delete values from the queue.
+ * @brief Main function
+ * @details
+ * Allows the user to add and delete values from the queue.
  * Also allows user to display values in the queue.
  * @returns 0 on exit
  */

--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -19,7 +19,7 @@
 #include <iostream> /// for io operations
 #include <vector>   /// for std::vector
 
-constexpr uint8_t max_size{10};
+constexpr uint8_t max_size{10}; ///< Maximum size of the queue
 
 /**
  * @namespace data_structures

--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -7,27 +7,25 @@
 #include <iostream>
 #include <vector>
 
-constexpr int max_size = 10;
+constexpr uint8_t max_size{10};
 
 class Queue_Array {
 public:
     Queue_Array();
-    void enqueue(int);
+    void enqueue(const int8_t&);
     int dequeue();
     void display() const;
 private:
-    int front;
-    int rear;
-    std::vector<int> arr;
+    int8_t front{-1};
+    int8_t rear{-1};
+    std::vector<int8_t> arr{};
 };
 
 Queue_Array::Queue_Array() {
-    front = -1;
-    rear = -1;
     arr.resize(max_size);
 }
 
-void Queue_Array::enqueue(const int ele) {
+void Queue_Array::enqueue(const int8_t& ele) {
     if (rear == arr.size() - 1) {
         std::cout << "\nStack is full";
     } else if (front == -1 && rear == -1) {
@@ -40,7 +38,7 @@ void Queue_Array::enqueue(const int ele) {
 }
 
 int Queue_Array::dequeue() {
-    int d{0};
+    int8_t d{0};
     if (front == -1) {
         std::cout << "\nstack is empty ";
         return 0;
@@ -58,7 +56,7 @@ void Queue_Array::display() const {
     if (front == -1) {
         std::cout << "\nStack is empty";
     } else {
-        for (int i{front}; i <= rear; ++i) std::cout << arr.at(i) << " ";
+        for (int8_t i{front}; i <= rear; ++i) std::cout << arr.at(i) << " ";
     }
 }
 
@@ -71,7 +69,7 @@ int main() {
     std::cout << "\n2. dequeue(Deletion)";
     std::cout << "\n3. Display";
     std::cout << "\n4. Exit";
-    while (1) {
+    while (true) {
         std::cout << "\nEnter your choice ";
         std::cin >> op;
         if (op == 1) {

--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -19,7 +19,7 @@
 #include <iostream> /// for io operations
 #include <vector>   /// for std::vector
 
-constexpr uint8_t max_size{10}; ///< Maximum size of the queue
+constexpr uint16_t max_size{10}; ///< Maximum size of the queue
 
 /**
  * @namespace data_structures

--- a/data_structures/queue_using_array.cpp
+++ b/data_structures/queue_using_array.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <vector>
 
-#define MAX_SIZE 10
+constexpr int max_size = 10;
 
 class Queue_Array {
 public:
@@ -24,7 +24,7 @@ private:
 Queue_Array::Queue_Array() {
     front = -1;
     rear = -1;
-    arr.resize(MAX_SIZE);
+    arr.resize(max_size);
 }
 
 void Queue_Array::enqueue(const int ele) {
@@ -40,7 +40,7 @@ void Queue_Array::enqueue(const int ele) {
 }
 
 int Queue_Array::dequeue() {
-    int d;
+    int d{0};
     if (front == -1) {
         std::cout << "\nstack is empty ";
         return 0;
@@ -63,7 +63,7 @@ void Queue_Array::display() const {
 }
 
 int main() {
-    int op, data;
+    int op{0}, data{0};
 
     Queue_Array ob;
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
In current version of `data_structures/queue_using_array.cpp` we have a really **bad bug (Resource leakage)** which is caused by using `new` operator without using `delete[]` after that ([Line 24](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/data_structures/queue_using_array.cpp#L24)); I fixed that by using `std::vector`. (If we want to still use C-Style array, just let me know and I will roll back to what we have now but I'll use `Smart Pointer` to fix that bug.)

Also I made some small refactoring to increase quality of code :)

If any thing need to be changed, just let me know that and after that it will be ready :)

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1428"><img src="https://gitpod.io/api/apps/github/pbs/github.com/farbodahm/C-Plus-Plus.git/6c68dc39c0b0317f47aff80774b2201136f5d9b3.svg" /></a>

