### PR TITLE
fix: Update copyright notice/year to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 TheAlgorithms
+Copyright (c) 2016-2021 TheAlgorithms and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->

- Single PR that updates the copyright year to 2021.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes:

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1440"><img src="https://gitpod.io/api/apps/github/pbs/github.com/Panquesito7/C-Plus-Plus.git/fe76acf72a58e63b235d4cfc19724b6ae252d454.svg" /></a>

