### PR TITLE
Fix: Remove <bits/stdc++.h> header because we were simply not using it.

### DIFF
--- a/dynamic_programming/longest_increasing_subsequence.cpp
+++ b/dynamic_programming/longest_increasing_subsequence.cpp
@@ -1,6 +1,6 @@
 // Program to calculate length of longest increasing subsequence in an array
 #include <iostream>
-#include <limits.h>
+#include <climits>
 
 using namespace std;
 

--- a/dynamic_programming/longest_increasing_subsequence.cpp
+++ b/dynamic_programming/longest_increasing_subsequence.cpp
@@ -1,6 +1,9 @@
 // Program to calculate length of longest increasing subsequence in an array
-#include <bits/stdc++.h>
+#include <iostream>
+#include <limits.h>
+
 using namespace std;
+
 int LIS(int a[], int n) {
     int lis[n];
     for (int i = 0; i < n; ++i) {
@@ -12,7 +15,7 @@ int LIS(int a[], int n) {
                 lis[i] = lis[j] + 1;
         }
     }
-    int res = 0;
+    int res = INT_MIN;
     for (int i = 0; i < n; ++i) {
         res = max(res, lis[i]);
     }


### PR DESCRIPTION
### **Description:**

- Remove `bits/stdc++.h` because we were simply not using it. In this case, simply using `iostream` does the work

- Initialized `res` with `INT_MIN` because it's generally less error-prone when used with `max`. Since, we are using limits, we might as well include `limts.h`



#### Checklist

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.


<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1499"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

