### PR TITLE
Issue #1536 - [BUG] check_prime.cpp returns incorrect output for 9

### DIFF
--- a/math/check_prime.cpp
+++ b/math/check_prime.cpp
@@ -29,7 +29,7 @@ bool is_prime(T num) {
         return 0;
     }
     if (num >= 3) {
-        for (T i = 3; (i * i) < (num); i = (i + 2)) {
+        for (T i = 3; (i * i) <= (num); i = (i + 2)) {
             if ((num % i) == 0) {
                 result = false;
                 break;


### PR DESCRIPTION
#### Description of Change
Fix for Issue #1536 - [BUG] check_prime.cpp returns incorrect output for 9

#### Checklist
- [x ] Added description of change
- [x ] Added tests and example, test must pass
- [x ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [ x] I acknowledge that all my contributions will be made under the project's license.

Notes: Updating the check_prime.cpp. It was giving wrong output for n = 9

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1537"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

