### PR TITLE
fix : check_prime.cpp bug

### DIFF
--- a/math/check_prime.cpp
+++ b/math/check_prime.cpp
@@ -29,7 +29,11 @@ bool is_prime(T num) {
         return 0;
     }
     if (num >= 3) {
-        for (T i = 3; (i * i) < (num); i = (i + 2)) {
+    /*
+    * @brief
+    * changed '<' to '<=' to tackle the case when num is a perfect square
+    */
+        for (T i = 3; (i * i) <= (num); i = (i + 2)) {
             if ((num % i) == 0) {
                 result = false;
                 break;


### PR DESCRIPTION
Changed '<' to '<=' in the for statement of is_prime function to tackle the
case when num is an odd perfect square.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [ ] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [ ] Relevant documentation/comments is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [ ] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1546"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

