### PR TITLE
docs: fix typo in binary_search docs

### DIFF
--- a/search/binary_search.cpp
+++ b/search/binary_search.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 
 /** binary_search function
- * \param [in] a array to sort
+ * \param [in] a array to search
  * \param [in] r right hand limit = \f$n-1\f$
  * \param [in] key value to find
  * \returns index if T is found


### PR DESCRIPTION
#### Description of Change

The docs for the `binary_search` function say that input parameter array `a` is the 'array to sort'. I believe this should say 'array to **search**', since the function _searches_ the array, and doesn't sort it.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->

Change 'sort' to 'search' in docs for the `binary_search` function.

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1572"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

