### PR TITLE
feat: Unleash full power of the stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,4 +16,3 @@ jobs:
           exempt-pr-labels: 'dont-close,approved'
           days-before-stale: 30
           days-before-close: 7
-          operations-per-run: 5


### PR DESCRIPTION
Set stale bot action limit to default because it's actually GitHub API action limit and not the number of issues/PRs it marks per run as I thought

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1607"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

