### PR TITLE
fix: Array right rotation

### DIFF
--- a/operations_on_datastructures/array_right_rotation.cpp
+++ b/operations_on_datastructures/array_right_rotation.cpp
@@ -50,10 +50,10 @@ std::vector<int32_t> shift_right(const std::vector<int32_t> &array,
         return {};  ///< We got an invalid shift, return empty array
     }
     std::vector<int32_t> res(array.size());  ///< Result array
-    for (int i = shift; i < array.size(); i++) {
+    for (size_t i = shift; i < array.size(); i++) {
         res[i] = array[i - shift];  ///< Add values after the shift index
     }
-    for (int i = 0; i < shift; i++) {
+    for (size_t i = 0; i < shift; i++) {
         res[i] =
             array[array.size() - shift + i];  ///< Add the values from the start
     }


### PR DESCRIPTION
#### Description of Change
Rewrote array_right_rotation using code from array_left_rotation. Added documentation and tests.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [x] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: I rewrote the code based off my other PR on array_left_rotation and used std::vector instead of a regular array, to increase safety and follow best practice

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1793"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

