### PR TITLE
fix: power_of_two algorithm redundant conditional 'else'

### DIFF
--- a/math/power_of_two.cpp
+++ b/math/power_of_two.cpp
@@ -46,9 +46,9 @@ int power_of_two(int n) {
     
     if (result == 0) {
         return 1;
-    } else {
-        return 0;
     }
+
+    return 0;
 }
 }  // namespace math
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->
Conditional structure was removed, due to redundancy

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->

A pr before this one, was accepted with a redundancy in the conditional, i'm just fixing it

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1936"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

