### PR TITLE
feat: move `gram_schmidt` to `numerical_methods`

### DIFF
--- a/numerical_methods/gram_schmidt.cpp
+++ b/numerical_methods/gram_schmidt.cpp
@@ -36,10 +36,10 @@
 #include "math.h"
 
 /**
- * @namespace linear_algebra
- * @brief Linear Algebra algorithms
+ * @namespace numerical_methods
+ * @brief Numerical Methods algorithms
  */
-namespace linear_algebra {
+namespace numerical_methods {
 /**
  * @namespace gram_schmidt
  * @brief Functions for [Gram Schmidt Orthogonalisation
@@ -173,7 +173,7 @@ void gram_schmidt(int r, const int& c,
     display(r, c, B);  // for displaying orthogoanlised vectors
 }
 }  // namespace gram_schmidt
-}  // namespace linear_algebra
+}  // namespace numerical_methods
 /**
  * Test Function. Process has been tested for 3 Sample Inputs
  * @returns void
@@ -183,12 +183,12 @@ static void test() {
         {{1, 0, 1, 0}, {1, 1, 1, 1}, {0, 1, 2, 1}}};
     std::array<std::array<double, 10>, 20> b1 = {{0}};
     double dot1 = 0;
-    linear_algebra::gram_schmidt::gram_schmidt(3, 4, a1, b1);
+    numerical_methods::gram_schmidt::gram_schmidt(3, 4, a1, b1);
     int flag = 1;
     for (int i = 0; i < 2; ++i) {
         for (int j = i + 1; j < 3; ++j) {
             dot1 = fabs(
-                linear_algebra::gram_schmidt::dot_product(b1[i], b1[j], 4));
+                numerical_methods::gram_schmidt::dot_product(b1[i], b1[j], 4));
             if (dot1 > 0.1) {
                 flag = 0;
                 break;
@@ -203,12 +203,12 @@ static void test() {
     std::array<std::array<double, 10>, 20> a2 = {{{3, 1}, {2, 2}}};
     std::array<std::array<double, 10>, 20> b2 = {{0}};
     double dot2 = 0;
-    linear_algebra::gram_schmidt::gram_schmidt(2, 2, a2, b2);
+    numerical_methods::gram_schmidt::gram_schmidt(2, 2, a2, b2);
     flag = 1;
     for (int i = 0; i < 1; ++i) {
         for (int j = i + 1; j < 2; ++j) {
             dot2 = fabs(
-                linear_algebra::gram_schmidt::dot_product(b2[i], b2[j], 2));
+                numerical_methods::gram_schmidt::dot_product(b2[i], b2[j], 2));
             if (dot2 > 0.1) {
                 flag = 0;
                 break;
@@ -223,12 +223,12 @@ static void test() {
     std::array<std::array<double, 10>, 20> a3 = {{{1, 2, 2}, {-4, 3, 2}}};
     std::array<std::array<double, 10>, 20> b3 = {{0}};
     double dot3 = 0;
-    linear_algebra::gram_schmidt::gram_schmidt(2, 3, a3, b3);
+    numerical_methods::gram_schmidt::gram_schmidt(2, 3, a3, b3);
     flag = 1;
     for (int i = 0; i < 1; ++i) {
         for (int j = i + 1; j < 2; ++j) {
             dot3 = fabs(
-                linear_algebra::gram_schmidt::dot_product(b3[i], b3[j], 3));
+                numerical_methods::gram_schmidt::dot_product(b3[i], b3[j], 3));
             if (dot3 > 0.1) {
                 flag = 0;
                 break;
@@ -268,14 +268,14 @@ int main() {
         std::cout << '\n';
     }
 
-    linear_algebra::gram_schmidt::gram_schmidt(r, c, A, B);
+    numerical_methods::gram_schmidt::gram_schmidt(r, c, A, B);
 
     double dot = 0;
     int flag = 1;  /// To check whether vectors are orthogonal or  not
     for (int i = 0; i < r - 1; ++i) {
         for (int j = i + 1; j < r; ++j) {
-            dot =
-                fabs(linear_algebra::gram_schmidt::dot_product(B[i], B[j], c));
+            dot = fabs(
+                numerical_methods::gram_schmidt::dot_product(B[i], B[j], c));
             if (dot > 0.1)  /// take make the process numerically stable, upper
                             /// bound for the dot product take 0.1
             {


### PR DESCRIPTION
#### Description of Change

Numerical methods already contains and uses linear algebra methods. Graham Schmidt doesn't need its own folder. I moved graham_schmidt.cpp to numerical_methods and deleted linear_algebra. An alternate option would be further compartmentalization of numerical methods into it's subjects: linear algebra, PDEs, etc.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
This file was authored by @Akanksha-Gupta920 so I would prefer his input.

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C-Plus-Plus/pull/1940"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

