### PR TITLE
fix: remove memory leak in `reverse_a_linked_list.cpp`

### DIFF
--- a/data_structures/reverse_a_linked_list.cpp
+++ b/data_structures/reverse_a_linked_list.cpp
@@ -190,8 +190,9 @@ void list::copy_all_nodes_from_list(const list& other) {
 list::list(const list& other) { copy_all_nodes_from_list(other); }
 
 list& list::operator=(const list& other) {
-    if (this == &other)
+    if (this == &other) {
         return *this;
+    }
     delete_all_nodes();
 
     copy_all_nodes_from_list(other);

--- a/data_structures/reverse_a_linked_list.cpp
+++ b/data_structures/reverse_a_linked_list.cpp
@@ -42,30 +42,40 @@ namespace linked_list {
 class Node {
  public:
     int32_t val;  /// value of the current link
-    Node *next;   /// pointer to the next value on the list
+    Node* next;   /// pointer to the next value on the list
 };
+
+Node* copy_all_nodes(const Node* const node) {
+    if (node) {
+        Node* res = new Node();
+        res->val = node->val;
+        res->next = copy_all_nodes(node->next);
+        return res;
+    }
+    return nullptr;
+}
 
 /**
  * A list class containing a sequence of links
  */
 class list {
  private:
-    Node *head;  // link before the actual first element
+    Node* head = nullptr;  // link before the actual first element
+    void delete_all_nodes();
+    void copy_all_nodes_from_list(const list& other);
+
  public:
-    /**
-     * List constructor. Initializes the first link.
-     */
-    list() {
-        head = nullptr;  // Initialize the first link
-    }
-    bool isEmpty();
+    bool isEmpty() const;
     void insert(int32_t new_elem);
     void reverseList();
-    void display();
-    int32_t top();
-    int32_t last();
-    int32_t traverse(int32_t index);
+    void display() const;
+    int32_t top() const;
+    int32_t last() const;
+    int32_t traverse(int32_t index) const;
     ~list();
+    list() = default;
+    list(const list& other);
+    list& operator=(const list& other);
 };
 
 /**
@@ -73,7 +83,7 @@ class list {
  * @returns true if the list is empty
  * @returns false if the list is not empty
  */
-bool list::isEmpty() { return head == nullptr; }
+bool list::isEmpty() const { return head == nullptr; }
 
 /**
  * @brief Utility function that adds a new element at the end of the list
@@ -81,8 +91,8 @@ bool list::isEmpty() { return head == nullptr; }
  */
 void list::insert(int32_t n) {
     try {
-        Node *new_node = new Node();
-        Node *temp = nullptr;
+        Node* new_node = new Node();
+        Node* temp = nullptr;
         new_node->val = n;
         new_node->next = nullptr;
         if (isEmpty()) {
@@ -94,7 +104,7 @@ void list::insert(int32_t n) {
             }
             temp->next = new_node;
         }
-    } catch (std::bad_alloc &exception) {
+    } catch (std::bad_alloc& exception) {
         std::cerr << "bad_alloc detected: " << exception.what() << "\n";
     }
 }
@@ -105,7 +115,7 @@ void list::insert(int32_t n) {
  * @returns void
  */
 void list::reverseList() {
-    Node *curr = head;
+    Node* curr = head;
     Node *prev = nullptr, *next_node = nullptr;
     while (curr != nullptr) {
         next_node = curr->next;
@@ -120,7 +130,7 @@ void list::reverseList() {
  * @brief Utility function to find the top element of the list
  * @returns the top element of the list
  */
-int32_t list::top() {
+int32_t list::top() const {
     if (!isEmpty()) {
         return head->val;
     } else {
@@ -131,9 +141,9 @@ int32_t list::top() {
  *  @brief Utility function to find the last element of the list
  *  @returns the last element of the list
  */
-int32_t list::last() {
+int32_t list::last() const {
     if (!isEmpty()) {
-        Node *t = head;
+        Node* t = head;
         while (t->next != nullptr) {
             t = t->next;
         }
@@ -146,8 +156,8 @@ int32_t list::last() {
  *  @brief Utility function to find the i th element of the list
  *  @returns the i th element of the list
  */
-int32_t list::traverse(int32_t index) {
-    Node *current = head;
+int32_t list::traverse(int32_t index) const {
+    Node* current = head;
 
     int count = 0;
     while (current != nullptr) {
@@ -163,12 +173,29 @@ int32_t list::traverse(int32_t index) {
     exit(1);
 }
 
-list::~list() {
+void list::delete_all_nodes() {
     while (head != nullptr) {
         const auto tmp_node = head->next;
         delete head;
         head = tmp_node;
     }
+}
+
+list::~list() { delete_all_nodes(); }
+
+void list::copy_all_nodes_from_list(const list& other) {
+    head = copy_all_nodes(other.head);
+}
+
+list::list(const list& other) { copy_all_nodes_from_list(other); }
+
+list& list::operator=(const list& other) {
+    if (this == &other)
+        return *this;
+    delete_all_nodes();
+
+    copy_all_nodes_from_list(other);
+    return *this;
 }
 
 }  // namespace linked_list
@@ -203,10 +230,60 @@ static void test() {
 }
 
 /**
+ * @brief tests copy constructor
+ */
+void test_copy_constructor() {
+    data_structures::linked_list::list L;
+    L.insert(10);
+    L.insert(20);
+    L.insert(30);
+    data_structures::linked_list::list otherList(L);
+    otherList.insert(40);
+
+    L.insert(400);
+
+    assert(L.top() == 10);
+    assert(otherList.top() == 10);
+    assert(L.traverse(1) == 20);
+    assert(otherList.traverse(1) == 20);
+
+    assert(L.traverse(2) == 30);
+    assert(otherList.traverse(2) == 30);
+
+    assert(L.last() == 400);
+    assert(otherList.last() == 40);
+}
+
+void test_assignment_operator() {
+    data_structures::linked_list::list L;
+    data_structures::linked_list::list otherList;
+    L.insert(10);
+    L.insert(20);
+    L.insert(30);
+    otherList = L;
+
+    otherList.insert(40);
+    L.insert(400);
+
+    assert(L.top() == 10);
+    assert(otherList.top() == 10);
+    assert(L.traverse(1) == 20);
+    assert(otherList.traverse(1) == 20);
+
+    assert(L.traverse(2) == 30);
+    assert(otherList.traverse(2) == 30);
+
+    assert(L.last() == 400);
+    assert(otherList.last() == 40);
+}
+
+/**
  * @brief Main function
  * @returns 0 on exit
  */
 int main() {
     test();  // run self-test implementations
+    test_copy_constructor();
+    test_assignment_operator();
     return 0;
 }

--- a/data_structures/reverse_a_linked_list.cpp
+++ b/data_structures/reverse_a_linked_list.cpp
@@ -65,6 +65,7 @@ class list {
     int32_t top();
     int32_t last();
     int32_t traverse(int32_t index);
+    ~list();
 };
 
 /**
@@ -160,6 +161,14 @@ int32_t list::traverse(int32_t index) {
     /* if we get to this line,the caller was asking for a non-existent element
     so we assert fail */
     exit(1);
+}
+
+list::~list() {
+    while (head != nullptr) {
+        const auto tmp_node = head->next;
+        delete head;
+        head = tmp_node;
+    }
 }
 
 }  // namespace linked_list

--- a/data_structures/reverse_a_linked_list.cpp
+++ b/data_structures/reverse_a_linked_list.cpp
@@ -24,7 +24,6 @@
 
 #include <cassert>   /// for assert
 #include <iostream>  /// for I/O operations
-#include <memory>    /// for dynamic memory
 #include <new>       /// for managing  dynamic storage
 
 /**

--- a/data_structures/reverse_a_linked_list.cpp
+++ b/data_structures/reverse_a_linked_list.cpp
@@ -47,6 +47,7 @@ class Node {
 
 Node* copy_all_nodes(const Node* const node) {
     if (node) {
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
         Node* res = new Node();
         res->val = node->val;
         res->next = copy_all_nodes(node->next);
@@ -58,6 +59,7 @@ Node* copy_all_nodes(const Node* const node) {
 /**
  * A list class containing a sequence of links
  */
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 class list {
  private:
     Node* head = nullptr;  // link before the actual first element
@@ -91,6 +93,7 @@ bool list::isEmpty() const { return head == nullptr; }
  */
 void list::insert(int32_t n) {
     try {
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
         Node* new_node = new Node();
         Node* temp = nullptr;
         new_node->val = n;


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->
In order to remove a memory leak in [`reverse_a_linked_list.cpp`](https://github.com/TheAlgorithms/C-Plus-Plus/blob/0f20cdcf8f49c2b8f2c128a2ac7b22819a44a680/data_structures/reverse_a_linked_list.cpp) I have added a destructor to the class `list`. Furthermore I made some minor modifications, namely:
- removed unused header,
- added copy constructor and assignment operator,
- made some member functions `const`,
- suppressed some warnings related to lack of move copy constructor and move assignment operator and using the `new` operator.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Removes a memory leak in [`reverse_a_linked_list.cpp`](https://github.com/TheAlgorithms/C-Plus-Plus/blob/0f20cdcf8f49c2b8f2c128a2ac7b22819a44a680/data_structures/reverse_a_linked_list.cpp).