### PR TITLE
fix: cover the cases `n == 0` and `m < n` in `N_bonacci`

### DIFF
--- a/math/n_bonacci.cpp
+++ b/math/n_bonacci.cpp
@@ -15,10 +15,9 @@
  * @author [Swastika Gupta](https://github.com/Swastyy)
  */
 
-#include <algorithm>  /// for std::is_equal, std::swap
-#include <cassert>    /// for assert
-#include <iostream>   /// for IO operations
-#include <vector>     /// for std::vector
+#include <cassert>   /// for assert
+#include <iostream>  /// for std::cout
+#include <vector>    /// for std::vector
 
 /**
  * @namespace math

--- a/math/n_bonacci.cpp
+++ b/math/n_bonacci.cpp
@@ -68,56 +68,29 @@ std::vector<uint64_t> N_bonacci(const uint64_t &n, const uint64_t &m) {
  * @returns void
  */
 static void test() {
-    assert(math::n_bonacci::N_bonacci(1, 1) == std::vector<uint64_t>{1});
-    // n = 1 m = 2 return [1, 1]
-    std::cout << "1st test";
-    std::vector<uint64_t> arr1 = math::n_bonacci::N_bonacci(
-        1, 2);  // first input is the param n and second one is the param m for
-                // N-bonacci func
-    std::vector<uint64_t> output_array1 = {
-        1, 1};  // It is the expected output series of length m
-    assert(std::equal(std::begin(arr1), std::end(arr1),
-                      std::begin(output_array1)));
-    std::cout << "passed" << std::endl;
+    struct TestCase {
+        const uint64_t n;
+        const uint64_t m;
+        const std::vector<uint64_t> expected;
+        TestCase(const uint64_t in_n, const uint64_t in_m,
+                 std::initializer_list<uint64_t> data)
+            : n(in_n), m(in_m), expected(data) {
+            assert(data.size() == m);
+        }
+    };
+    const std::vector<TestCase> test_cases = {
+        TestCase(1, 1, {1}),
+        TestCase(1, 2, {1, 1}),
+        TestCase(1, 3, {1, 1, 1}),
+        TestCase(5, 15, {0, 0, 0, 0, 1, 1, 2, 4, 8, 16, 31, 61, 120, 236, 464}),
+        TestCase(
+            6, 17,
+            {0, 0, 0, 0, 0, 1, 1, 2, 4, 8, 16, 32, 63, 125, 248, 492, 976}),
+        TestCase(56, 15, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})};
 
-    // n = 5 m = 15 return [0, 0, 0, 0, 1, 1, 2, 4, 8, 16, 31, 61, 120, 236,
-    // 464]
-    std::cout << "2nd test";
-    std::vector<uint64_t> arr2 = math::n_bonacci::N_bonacci(
-        5, 15);  // first input is the param n and second one is the param m for
-                 // N-bonacci func
-    std::vector<uint64_t> output_array2 = {
-        0, 0,  0,  0,  1,   1,   2,  4,
-        8, 16, 31, 61, 120, 236, 464};  // It is the expected output series of
-                                        // length m
-    assert(std::equal(std::begin(arr2), std::end(arr2),
-                      std::begin(output_array2)));
-    std::cout << "passed" << std::endl;
-
-    // n = 6 m = 17 return [0, 0, 0, 0, 0, 1, 1, 2, 4, 8, 16, 32, 63, 125, 248,
-    // 492, 976]
-    std::cout << "3rd test";
-    std::vector<uint64_t> arr3 = math::n_bonacci::N_bonacci(
-        6, 17);  // first input is the param n and second one is the param m for
-                 // N-bonacci func
-    std::vector<uint64_t> output_array3 = {
-        0, 0,  0,  0,  0,   1,   1,   2,  4,
-        8, 16, 32, 63, 125, 248, 492, 976};  // It is the expected output series
-                                             // of length m
-    assert(std::equal(std::begin(arr3), std::end(arr3),
-                      std::begin(output_array3)));
-    std::cout << "passed" << std::endl;
-
-    // n = 56 m = 15 return [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    std::cout << "4th test";
-    std::vector<uint64_t> arr4 = math::n_bonacci::N_bonacci(
-        56, 15);  // first input is the param n and second one is the param m
-                  // for N-bonacci func
-    std::vector<uint64_t> output_array4 = {
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0};  // It is the expected output series of length m
-    assert(std::equal(std::begin(arr4), std::end(arr4),
-                      std::begin(output_array4)));
+    for (const auto &tc : test_cases) {
+        assert(math::n_bonacci::N_bonacci(tc.n, tc.m) == tc.expected);
+    }
     std::cout << "passed" << std::endl;
 }
 

--- a/math/n_bonacci.cpp
+++ b/math/n_bonacci.cpp
@@ -39,10 +39,17 @@ namespace n_bonacci {
  * @returns the n-bonacci sequence as vector array
  */
 std::vector<uint64_t> N_bonacci(const uint64_t &n, const uint64_t &m) {
-    std::vector<uint64_t> a(m, 0);  // we create an empty array of size m
+    std::vector<uint64_t> a(
+        m, 0);  // we create an array of size m filled with zeros
+    if (m < n) {
+        return a;
+    }
 
     a[n - 1] = 1;  /// we initialise the (n-1)th term as 1 which is the sum of
                    /// preceding N zeros
+    if (n == m) {
+        return a;
+    }
     a[n] = 1;  /// similarily the sum of preceding N zeros and the (N+1)th 1 is
                /// also 1
     for (uint64_t i = n + 1; i < m; i++) {
@@ -61,10 +68,11 @@ std::vector<uint64_t> N_bonacci(const uint64_t &n, const uint64_t &m) {
  * @returns void
  */
 static void test() {
-    // n = 1 m = 1 return [1, 1]
+    assert(math::n_bonacci::N_bonacci(1, 1) == std::vector<uint64_t>{1});
+    // n = 1 m = 2 return [1, 1]
     std::cout << "1st test";
     std::vector<uint64_t> arr1 = math::n_bonacci::N_bonacci(
-        1, 1);  // first input is the param n and second one is the param m for
+        1, 2);  // first input is the param n and second one is the param m for
                 // N-bonacci func
     std::vector<uint64_t> output_array1 = {
         1, 1};  // It is the expected output series of length m

--- a/math/n_bonacci.cpp
+++ b/math/n_bonacci.cpp
@@ -40,7 +40,7 @@ namespace n_bonacci {
 std::vector<uint64_t> N_bonacci(const uint64_t &n, const uint64_t &m) {
     std::vector<uint64_t> a(
         m, 0);  // we create an array of size m filled with zeros
-    if (m < n) {
+    if (m < n || n == 0) {
         return a;
     }
 
@@ -78,6 +78,10 @@ static void test() {
         }
     };
     const std::vector<TestCase> test_cases = {
+        TestCase(0, 0, {}),
+        TestCase(0, 1, {0}),
+        TestCase(0, 2, {0, 0}),
+        TestCase(1, 0, {}),
         TestCase(1, 1, {1}),
         TestCase(1, 2, {1, 1}),
         TestCase(1, 3, {1, 1, 1}),


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->
This PR fixes the implementation of [`N_bonacci`](https://github.com/TheAlgorithms/C-Plus-Plus/blob/4fc14710b60c265f265bd4d7c526207a5d477421/math/n_bonacci.cpp#L41), namely the result has always length equal to `m` and the case of `n == 0` is treated correctly.

Additional changes:
- fef05911cfd432864ef7efa27eed9c15244a0327 removes unused includes,
- ce85e26db138e3b7e1da093f169f35d1c5c920bc, a3d7134a09a1014b9b8b69364f5be0b30ae1f84d simplifies test and adds new test cases
- some minor updates of the comments

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added tests and example, test must pass
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Fixes a bug in [`n_bonacci.cpp`](https://github.com/TheAlgorithms/C-Plus-Plus/blob/4fc14710b60c265f265bd4d7c526207a5d477421/math/n_bonacci.cpp)