### PR TITLE
fix: Updated get_k_th() to consider inexistent value

### DIFF
--- a/data_structures/treap.cpp
+++ b/data_structures/treap.cpp
@@ -136,6 +136,10 @@ struct Treap {
      * @return The element ranked number k
      */
     int _get_k_th(int &x, int k) {
+        if (k <= 0 || k > size[root]) {
+            return -1;  // Element not found, return -1
+        }
+
         if (k <= size[childs[x][0]]) {
             return _get_k_th(childs[x][0], k);
         }
@@ -157,11 +161,9 @@ struct Treap {
         }
         if (k == key[x]) {
             return size[childs[x][0]] + 1;
-        }
-        else if (k < key[x]) {
+        } else if (k < key[x]) {
             return _get_rank(childs[x][0], k);
-        }
-        else {
+        } else {
             return size[childs[x][0]] + cnt[x] + _get_rank(childs[x][1], k);
         }
     }
@@ -246,6 +248,11 @@ static void test() {
     mTreap.insert(10);
     assert(mTreap.get_rank(10) == 7);
     assert(mTreap.get_predecessor(10) == 7);
+
+    // Testcases when elements are not present
+    assert(mTreap.get_k_th(10) == -1);   // Element not found
+    assert(mTreap.get_next(100) == -1);  // No successor for a large element
+    assert(mTreap.get_predecessor(0) == -1);  // No predecessor for a small element
 
     std::cout << "All tests have successfully passed!\n";
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->
For the _treap.cpp_ program in the _./data_structures_ directory, the _get_k_th()_ function did not consider the case when the input value does not exist (Segmentation Fault). I added an appropriate condition to check for the same and return a special value '-1' (might need to be changed). For the purpose of testing the same, I added a few more test cases to check if the code words with the required assertions.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added tests and example, test must pass
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Handling inexistent values in the treap.