### PR TITLE
fix: remove memory leak in `library_sort.cpp`

### DIFF
--- a/sorting/library_sort.cpp
+++ b/sorting/library_sort.cpp
@@ -69,6 +69,11 @@ void librarySort(int *index, int n) {
             index_pos_for_output++;
         }
     }
+    delete[] numbered;
+    delete[] gaps;
+    for (int i = 0; i < 2; ++i) {
+        delete[] library[i];
+    }
 }
 
 int main() {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->
There is a memory leak in [`library_sort.cpp`](https://github.com/TheAlgorithms/C-Plus-Plus/blob/23b133ae1eac4ad7e94e74da140d462180738413/sorting/library_sort.cpp). This PR fixes it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Remove memory leak in [`library_sort.cpp`](https://github.com/TheAlgorithms/C-Plus-Plus/blob/23b133ae1eac4ad7e94e74da140d462180738413/sorting/library_sort.cpp).
