### PR TITLE
fix: remove memory leak `get_size_of_linked_list.cpp`

### DIFF
--- a/operations_on_datastructures/get_size_of_linked_list.cpp
+++ b/operations_on_datastructures/get_size_of_linked_list.cpp
@@ -16,6 +16,20 @@ int getSize(Node *root) {
     return 1 + getSize(root->next);
 }
 
+/*
+ * @brief This function dealocates memory related to the given list
+ * It recursively deletes all of the nodes of the input list.
+ * @param room the root/head of the input list
+ * @warning Plese note that the memory for each node has to be alocated using new.
+ */
+void deleteList(Node *const root) {
+    if (root != NULL)
+    {
+        deleteList(root->next);
+        delete root;
+    }
+}
+
 int main() {
     Node *myList = new Node(0, NULL);  // Initializes the LinkedList
     Node *temp = myList;
@@ -31,6 +45,8 @@ int main() {
     std::cout << getSize(myList) << std::endl
               << getSize(secondList) << std::endl
               << getSize(thirdList) << std::endl;
+    deleteList(secondList);
+    deleteList(myList);
 
     return 0;
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->
[`get_size_of_linked_list.cpp`](https://github.com/TheAlgorithms/C-Plus-Plus/blob/23b133ae1eac4ad7e94e74da140d462180738413/operations_on_datastructures/get_size_of_linked_list.cpp) has a memory leak. This PR adds the function `deleteList` in order to fix it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [x] ~Added tests and example, test must pass~
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->

Removes memory leak in [`get_size_of_linked_list.cpp`](https://github.com/TheAlgorithms/C-Plus-Plus/blob/23b133ae1eac4ad7e94e74da140d462180738413/operations_on_datastructures/get_size_of_linked_list.cpp).
