### PR TITLE
fix: overflow when searching the middle of a segment

### DIFF
--- a/numerical_methods/bisection_method.cpp
+++ b/numerical_methods/bisection_method.cpp
@@ -55,7 +55,7 @@ int main() {
 
     // start iterations
     for (i = 0; i < MAX_ITERATIONS; i++) {
-        x = (a + b) / 2;
+        x = a + (b - a) / 2;
         z = eq(x);
         std::cout << "\n\nz: " << z << "\t[" << a << " , " << b
                   << " | Bisect: " << x << "]";


### PR DESCRIPTION
Fixed finding the middle of the segment. Now if "a" and "b" fit into the double type, then the middle too. In the previous implementation, there could be an exit beyond the size of double.
