### PR TITLE
adding missing cstdint for uint32_t

### DIFF
--- a/math/sieve_of_eratosthenes.cpp
+++ b/math/sieve_of_eratosthenes.cpp
@@ -10,7 +10,7 @@
  *
  * @see primes_up_to_billion.cpp prime_numbers.cpp
  */
-
+#include <cstdint>
 #include <cassert>
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
#### Description of Change

Tested on linux machine it turns out the adding `#include <cstdint>` in necessary . Tested sieve_of_eratosthenes.cpp file only
