### PR TITLE
fix: added required library <cstint> to avoid error in  dijakstra

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -87,5 +87,6 @@
     "xtree": "cpp",
     "xutility": "cpp",
     "climits": "cpp"
-  }
+  },
+  "cmake.configureOnOpen": false
 }

--- a/graph/bidirectional_dijkstra.cpp
+++ b/graph/bidirectional_dijkstra.cpp
@@ -19,7 +19,7 @@
 #include <queue>     /// for the priority_queue of distances
 #include <utility>   /// for make_pair function
 #include <vector>    /// for store the graph, the distances, and the path
-
+#include <cstdint>   /// added required library to avoid errors in int64_t definition
 constexpr int64_t INF = std::numeric_limits<int64_t>::max();
 
 /**


### PR DESCRIPTION
#### Description of Change
the int64_t wasn't defined in the directories of bidirectional-dijakstra so i added the call to <cstdint> library thus making it the algo executable
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [ ] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [ ] Relevant documentation/comments is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [ ] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
