### PR TITLE
fix: compilation failure with gcc >= 13

### DIFF
--- a/math/extended_euclid_algorithm.cpp
+++ b/math/extended_euclid_algorithm.cpp
@@ -11,6 +11,7 @@
  */
 #include <algorithm>  // for swap function
 #include <iostream>
+#include <cstdint>
 
 /**
  * function to update the coefficients per iteration


### PR DESCRIPTION
#### Description of Change
It appears that gcc13 reordered some headers, so `iostream` no longer includes `cstdint`.
Files using `cstdint` via `iostream` need to be updated.
I've only changed one file, but there's sure to be more that need changing (see #2698).

#### Checklist
- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: For testing - https://godbolt.org/z/6WWh3zs9G
