### PR TITLE
fix: remove memory leak from `reverse_binary_tree.cpp`

### DIFF
--- a/operations_on_datastructures/reverse_binary_tree.cpp
+++ b/operations_on_datastructures/reverse_binary_tree.cpp
@@ -91,6 +91,9 @@ class BinaryTree {
         return pivot;
     }
 
+    BinaryTree(const BinaryTree&) = delete;
+    BinaryTree& operator=(const BinaryTree&) = delete;
+
  public:
     /**
      * @brief Creates a BinaryTree with a root pointing to NULL.
@@ -100,6 +103,21 @@ class BinaryTree {
      * @brief Creates a BinaryTree with a root with an initial value.
      */
     explicit BinaryTree(int64_t data) { root = new Node(data); }
+
+    ~BinaryTree() {
+        std::vector<Node*> nodes;
+        nodes.emplace_back(root);
+        while (!nodes.empty()) {
+            const auto cur_node = nodes.back();
+            nodes.pop_back();
+            if (cur_node) {
+                nodes.emplace_back(cur_node->left);
+                nodes.emplace_back(cur_node->right);
+                delete cur_node;
+            }
+        }
+    }
+
     /**
      * @brief Adds a new Node to the Binary Tree
      */


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

This PR adds a destructor to [`BinaryTree`](https://github.com/TheAlgorithms/C-Plus-Plus/blob/7828b8e238ecff9b13f2ac4c4b863ece0e917981/operations_on_datastructures/reverse_binary_tree.cpp#L52). Furthermore the _copy constructor_ and the _assignment operator_ was explicitly deleted in order to... _simplify things_.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [x] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Removes the memory leak from [`reverse_binary_tree.cpp`](https://github.com/TheAlgorithms/C-Plus-Plus/blob/7828b8e238ecff9b13f2ac4c4b863ece0e917981/operations_on_datastructures/reverse_binary_tree.cpp).
