### PR TITLE
Update floyd_warshall.cpp

### DIFF
--- a/dynamic_programming/floyd_warshall.cpp
+++ b/dynamic_programming/floyd_warshall.cpp
@@ -51,7 +51,7 @@ void print(int dist[], int V) {
 
 // The main function that finds the shortest path from a vertex
 // to all other vertices using Floyd-Warshall Algorithm.
-void FloydWarshall(Graph graph) {
+void FloydWarshall(Graph& graph) {
     int V = graph.vertexNum;
     int dist[V][V];
 


### PR DESCRIPTION
Fix Segmentation fault due to the `Graph` being passed by value, and there not being a copy constructor. Adding the `&` for the `Graph` parameter changes the passing of the parameter to be passed by reference and circumvents the segmentation fault.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [x] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: Added an '&' to pass the `Graph` parameter by reference to avoid the segmentation fault that was being produced prior to this change.
