### PR TITLE
feat: added serializers

### DIFF
--- a/others/serialization.cpp
+++ b/others/serialization.cpp
@@ -1,16 +1,38 @@
 /**
- * @file
- * @brief A simple Serializer and Deserializer utility for fundamental data
- * types and strings.
+ * @file serialization.cpp
+ * @brief Utility for binary serialization and deserialization of fundamental
+ * data types and strings.
+ * @details
+ * Binary serialization converts data into its binary format for
+ * efficient storage and transmission, which is more compact and faster than
+ * text-based formats. This utility handles fundamental types like integers,
+ * doubles, and characters by writing their binary representation directly to a
+ * file using `reinterpret_cast`.
+ *
+ * ### Serializing:
+ * - **Fundamental Types**: Written directly in their binary form.
+ * - **Strings**: The string's length is written first, followed by the string
+ * data, and a `|` delimiter to mark the end.
+ *
+ * ### Deserializing:
+ * - **Fundamental Types**: Reads the binary data back into the appropriate
+ * type.
+ * - **Strings**: Reads the string's length, followed by the string data, and
+ * checks for the `|` delimiter. An error is raised if the delimiter is missing.
+ *
+ * @author [SharonIV0X86](https://github.com/SharonIV0X86)
  */
+
 #include <cassert>      // for assert
 #include <cstdint>      // for std::uint32_t
+#include <cstdio>       // for std::remove()
 #include <fstream>      // for std::ifstream std::ofstream
 #include <iostream>     // for std::ios std::cout std::cerr
 #include <string>       // for std::string
 #include <type_traits>  // for std::is_fundamental
 
 /**
+ * @class Serializer
  * @brief A utility class for serializing fundamental data types and strings to
  * a binary file.
  */
@@ -104,60 +126,132 @@ class Deserializer {
  * @return void
  */
 void tests() {
-    std::ofstream outFile("test_output.bin", std::ios::binary);
-    if (!outFile) {
-        std::cerr << "Error opening file for output.\n";
-        return;
+    try {
+        std::ofstream outFile("test_output.bin", std::ios::binary);
+        if (!outFile) {
+            throw std::runtime_error("Error opening file for output.");
+        }
+
+        int testInt = 12345;
+        double testDouble = 9876.54321;
+        char testChar = 'A';
+        std::string testString = "Testing String Serialization!";
+
+        // Serialize the data
+        Serializer::serialize(outFile, testInt);
+        Serializer::serialize(outFile, testDouble);
+        Serializer::serialize(outFile, testChar);
+        Serializer::serialize(outFile, testString);
+
+        outFile.close();
+
+        std::ifstream inFile("test_output.bin", std::ios::binary);
+        if (!inFile) {
+            throw std::runtime_error("Error opening file for input.");
+        }
+
+        int intResult;
+        double doubleResult;
+        char charResult;
+        std::string stringResult;
+
+        // Deserialize the data
+        Deserializer::deserialize(inFile, intResult);
+        Deserializer::deserialize(inFile, doubleResult);
+        Deserializer::deserialize(inFile, charResult);
+        Deserializer::deserialize(inFile, stringResult);
+
+        inFile.close();
+
+        // Assert that the original and deserialized values are the same
+        assert(testInt == intResult);
+        assert(testDouble == doubleResult);
+        assert(testChar == charResult);
+        assert(testString == stringResult);
+
+        std::cout << "All tests passed!\n";
+    } catch (const std::exception &e) {
+        std::cerr << "Test failed: " << e.what() << std::endl;
     }
 
-    int testInt = 12345;
-    double testDouble = 9876.54321;
-    char testChar = 'A';
-    std::string testString = "Testing String Serialization!";
-
-    // Serialize the data
-    Serializer::serialize(outFile, testInt);
-    Serializer::serialize(outFile, testDouble);
-    Serializer::serialize(outFile, testChar);
-    Serializer::serialize(outFile, testString);
-
-    outFile.close();
-
-    std::ifstream inFile("test_output.bin", std::ios::binary);
-    if (!inFile) {
-        std::cerr << "Error opening file for input.\n";
-        return;
+    // Test for file opening failure
+    try {
+        std::ifstream inFile("non_existent_file.bin", std::ios::binary);
+        if (!inFile) {
+            throw std::runtime_error("Error opening non-existent file.");
+        }
+    } catch (const std::runtime_error &e) {
+        assert(std::string(e.what()) == "Error opening non-existent file.");
+        std::cout << "File opening error test passed!\n";
     }
 
-    int intResult;
-    double doubleResult;
-    char charResult;
-    std::string stringResult;
+    // Test for deserialization failure (e.g., wrong file format)
+    try {
+        std::ofstream outFile("wrong_format.bin", std::ios::binary);
+        outFile << "This is not serialized data";  // Writing incorrect data
+        outFile.close();
 
-    // Deserialize the data
-    Deserializer::deserialize(inFile, intResult);
-    Deserializer::deserialize(inFile, doubleResult);
-    Deserializer::deserialize(inFile, charResult);
-    Deserializer::deserialize(inFile, stringResult);
+        std::ifstream inFile("wrong_format.bin", std::ios::binary);
+        if (!inFile) {
+            throw std::runtime_error("Error opening file for input.");
+        }
 
-    inFile.close();
+        int intResult;
+        // Deserialize expecting binary data, this should fail
+        Deserializer::deserialize(inFile, intResult);
 
-    // Assert that the original and deserialized values are the same
-    assert(testInt == intResult);
-    assert(testDouble == doubleResult);
-    assert(testChar == charResult);
-    assert(testString == stringResult);
+        inFile.close();
+    } catch (const std::exception &e) {
+        std::cout << "Deserialization error test passed: " << e.what()
+                  << std::endl;
+    }
 
-    std::cout << "All tests passed!\n";
+    // Test for string too large error
+    try {
+        std::ofstream outFile("large_string.bin", std::ios::binary);
+        std::string largeString(1024 * 1024 + 1,
+                                'A');  // String larger than 1MB
+        Serializer::serialize(outFile,
+                              largeString);  // Should succeed in serialization
+        outFile.close();
+
+        std::ifstream inFile("large_string.bin", std::ios::binary);
+        std::string deserializedString;
+        Deserializer::deserialize(
+            inFile, deserializedString);  // Should fail in deserialization
+        inFile.close();
+    } catch (const std::runtime_error &e) {
+        assert(std::string(e.what()) ==
+               "Deserialized string length is too large.");
+        std::cout << "Large string error test passed!\n";
+    }
+
+    // Test for missing delimiter
+    try {
+        std::ofstream outFile("missing_delimiter.bin", std::ios::binary);
+        std::string testString = "Test String";
+        std::uint32_t length = testString.size();
+        outFile.write(reinterpret_cast<const char *>(&length), sizeof(length));
+        outFile.write(testString.c_str(), length);  // No delimiter
+        outFile.close();
+
+        std::ifstream inFile("missing_delimiter.bin", std::ios::binary);
+        std::string deserializedString;
+        Deserializer::deserialize(inFile, deserializedString);  // Should fail
+        inFile.close();
+    } catch (const std::runtime_error &e) {
+        assert(std::string(e.what()) ==
+               "Delimiter '|' not found after string.");
+        std::cout << "Missing delimiter error test passed!\n";
+    }
+    // Clean up temporary files that were created during testing.
+    std::remove("test_output.bin");
+    std::remove("wrong_format.bin");
+    std::remove("large_string.bin");
+    std::remove("missing_delimiter.bin");
 }
 
 int main() {
     tests();
-
     return 0;
 }
-
-/**
- * @brief A test suite to perform extensive testing on the Serializer and
- * Deserializer.
- */

--- a/others/serialization.cpp
+++ b/others/serialization.cpp
@@ -41,7 +41,7 @@ class Serializer {
      * content.
      */
     static void serialize(std::ofstream &out, const std::string &data) {
-        ssize_t length = data.size();
+        std::uint32_t length = data.size();
         serialize(out, length);           // Serialize the length of the string.
         out.write(data.c_str(), length);  // Serialize the string characters.
         out.put('|');  // Add a delimiter to denote the end of the string.
@@ -81,7 +81,7 @@ class Deserializer {
      * delimiter '|' is not found.
      */
     static void deserialize(std::ifstream &in, std::string &data) {
-        ssize_t length;
+        std::uint32_t length;
         deserialize(in, length);  // Deserialize the length of the string.
 
         if (length > 1024 * 1024)  // Sanity check to prevent huge strings.

--- a/others/serialization.cpp
+++ b/others/serialization.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <cassert> 
 
 /**
  * @file
@@ -139,7 +140,6 @@ int main() {
  * @brief A test suite to perform extensive testing on the Serializer and
  * Deserializer.
  */
-#include <cassert>  // For assert
 
 void runTests() {
     std::ofstream outFile("test_output.bin", std::ios::binary);

--- a/others/serialization.cpp
+++ b/others/serialization.cpp
@@ -55,11 +55,11 @@ class Serializer {
     }
 
     /**
-     * Serializes a string to a binary file.
+     * @brief Serializes a string to a binary file.
      * @param out The output stream (std::ofstream).
      * @param data The string to be serialized.
      *
-     * The string is serialized by first storing its length, followed by the
+     * @note The string is serialized by first storing its length, followed by the
      * content.
      */
     static void serialize(std::ofstream &out, const std::string &data) {
@@ -77,7 +77,7 @@ class Serializer {
 class Deserializer {
  public:
     /**
-     * Deserializes fundamental data types (like int, float, double, etc.) from
+     * @brief Deserializes fundamental data types (like int, float, double, etc.) from
      * a binary file.
      * @tparam T The type of the data to be deserialized.
      * @param in The input stream (std::ifstream).
@@ -94,7 +94,7 @@ class Deserializer {
     }
 
     /**
-     * Deserializes a string from a binary file.
+     * @brief Deserializes a string from a binary file.
      * @param in The input stream (std::ifstream).
      * @param data The string where the deserialized content will be stored.
      *

--- a/others/serialization.cpp
+++ b/others/serialization.cpp
@@ -8,12 +8,11 @@
  * types and strings.
  */
 
-
 class Serializer {
  public:
     /**
-     * Serializes fundamental data types (like int, float, double, etc.) to a
-     * binary file.
+     * @brief Serializes fundamental data types (like int, float, double, etc.)
+     * to a binary file.
      * @tparam T The type of the data to be serialized.
      * @param out The output stream (std::ofstream).
      * @param data The data to be serialized.
@@ -22,9 +21,7 @@ class Serializer {
      */
     template <typename T>
     static void serialize(std::ofstream &out, const T &data) {
-        static_assert(
-            std::is_fundamental<T>::value,
-            "Non-fundamental types are not allowed for this function!");
+        static_assert(std::is_fundamental<T>::value, "Non-fundamental types are not allowed for this function!");
         out.write(reinterpret_cast<const char *>(&data), sizeof(T));
     }
 
@@ -119,7 +116,7 @@ int main() {
     Serializer::serialize(outFile, num);
     Serializer::serialize(outFile, pi);
     Serializer::serialize(outFile, message);
-    outFile.close();  
+    outFile.close();
 
     int numRead;
     float piRead;
@@ -142,6 +139,8 @@ int main() {
  * @brief A test suite to perform extensive testing on the Serializer and
  * Deserializer.
  */
+#include <cassert>  // For assert
+
 void runTests() {
     std::ofstream outFile("test_output.bin", std::ios::binary);
     if (!outFile) {
@@ -181,8 +180,11 @@ void runTests() {
 
     inFile.close();
 
-    std::cout << "Test Int: " << intResult << "\n";
-    std::cout << "Test Double: " << doubleResult << "\n";
-    std::cout << "Test Char: " << charResult << "\n";
-    std::cout << "Test String: " << stringResult << "\n";
+    // Assert that the original and deserialized values are the same
+    assert(testInt == intResult);
+    assert(testDouble == doubleResult);
+    assert(testChar == charResult);
+    assert(testString == stringResult);
+
+    std::cout << "All tests passed!\n";
 }

--- a/others/serialization.cpp
+++ b/others/serialization.cpp
@@ -251,7 +251,11 @@ void tests() {
     std::remove("missing_delimiter.bin");
 }
 
+/**
+ * @brief Main function
+ * @returns 0 on successful exit
+ */
 int main() {
-    tests();
+    tests(); // run self test implementations
     return 0;
 }

--- a/others/serialization.cpp
+++ b/others/serialization.cpp
@@ -1,0 +1,188 @@
+#include <fstream>
+#include <iostream>
+#include <string>
+
+/**
+ * @file
+ * @brief A simple Serializer and Deserializer utility for fundamental data
+ * types and strings.
+ */
+
+
+class Serializer {
+ public:
+    /**
+     * Serializes fundamental data types (like int, float, double, etc.) to a
+     * binary file.
+     * @tparam T The type of the data to be serialized.
+     * @param out The output stream (std::ofstream).
+     * @param data The data to be serialized.
+     *
+     * @note This function only works for fundamental types (primitives).
+     */
+    template <typename T>
+    static void serialize(std::ofstream &out, const T &data) {
+        static_assert(
+            std::is_fundamental<T>::value,
+            "Non-fundamental types are not allowed for this function!");
+        out.write(reinterpret_cast<const char *>(&data), sizeof(T));
+    }
+
+    /**
+     * Serializes a string to a binary file.
+     * @param out The output stream (std::ofstream).
+     * @param data The string to be serialized.
+     *
+     * The string is serialized by first storing its length, followed by the
+     * content.
+     */
+    static void serialize(std::ofstream &out, const std::string &data) {
+        ssize_t length = data.size();
+        serialize(out, length);           // Serialize the length of the string.
+        out.write(data.c_str(), length);  // Serialize the string characters.
+        out.put('|');  // Add a delimiter to denote the end of the string.
+    }
+};
+
+/**
+ * @class Deserializer
+ * A utility class for deserializing data from a binary file.
+ */
+class Deserializer {
+ public:
+    /**
+     * Deserializes fundamental data types (like int, float, double, etc.) from
+     * a binary file.
+     * @tparam T The type of the data to be deserialized.
+     * @param in The input stream (std::ifstream).
+     * @param data The variable where the deserialized data will be stored.
+     *
+     * @note This function only works for fundamental types (primitives).
+     */
+    template <typename T>
+    static void deserialize(std::ifstream &in, T &data) {
+        static_assert(
+            std::is_fundamental<T>::value,
+            "Non-fundamental types are not allowed for this function!");
+        in.read(reinterpret_cast<char *>(&data), sizeof(T));
+    }
+
+    /**
+     * Deserializes a string from a binary file.
+     * @param in The input stream (std::ifstream).
+     * @param data The string where the deserialized content will be stored.
+     *
+     * The string is deserialized by reading its length, followed by the
+     * characters, and finally validating the delimiter throws error if the
+     * delimiter '|' is not found.
+     */
+    static void deserialize(std::ifstream &in, std::string &data) {
+        ssize_t length;
+        deserialize(in, length);  // Deserialize the length of the string.
+
+        if (length > 1024 * 1024)  // Sanity check to prevent huge strings.
+        {
+            throw std::runtime_error(
+                "Deserialized string length is too large.");
+        }
+
+        data.resize(length);  // Resize the string to fit the incoming data.
+        in.read(&data[0], length);  // Read the string characters.
+        char delimiter;
+        in.get(delimiter);  // Check the delimiter.
+        if (delimiter != '|') {
+            throw std::runtime_error("Delimiter '|' not found after string.");
+        }
+    }
+};
+
+void runTests();
+
+/**
+ * Demonstrates the use of Serializer and Deserializer for fundamental types and
+ * strings.
+ */
+int main() {
+    std::ofstream outFile("output.bin", std::ios::binary);
+    std::ifstream inFile("output.bin", std::ios::binary);
+
+    if (!outFile || !inFile) {
+        std::cerr << "Error opening files.\n";
+        return 1;
+    }
+
+    // Data to be serialized.
+    int num = 42;
+    float pi = 3.14159f;
+    std::string message = "Hello, Sharon!";
+
+    Serializer::serialize(outFile, num);
+    Serializer::serialize(outFile, pi);
+    Serializer::serialize(outFile, message);
+    outFile.close();  
+
+    int numRead;
+    float piRead;
+    std::string messageRead;
+
+    // Deserialize the data.
+    Deserializer::deserialize(inFile, numRead);
+    Deserializer::deserialize(inFile, piRead);
+    Deserializer::deserialize(inFile, messageRead);
+    inFile.close();
+
+    std::cout << "Deserialized int: " << numRead << "\n";
+    std::cout << "Deserialized float: " << piRead << "\n";
+    std::cout << "Deserialized string: " << messageRead << "\n";
+
+    return 0;
+}
+
+/**
+ * @brief A test suite to perform extensive testing on the Serializer and
+ * Deserializer.
+ */
+void runTests() {
+    std::ofstream outFile("test_output.bin", std::ios::binary);
+    if (!outFile) {
+        std::cerr << "Error opening file for output.\n";
+        return;
+    }
+
+    int testInt = 12345;
+    double testDouble = 9876.54321;
+    char testChar = 'A';
+    std::string testString = "Testing String Serialization!";
+
+    // Serialize the data
+    Serializer::serialize(outFile, testInt);
+    Serializer::serialize(outFile, testDouble);
+    Serializer::serialize(outFile, testChar);
+    Serializer::serialize(outFile, testString);
+
+    outFile.close();
+
+    std::ifstream inFile("test_output.bin", std::ios::binary);
+    if (!inFile) {
+        std::cerr << "Error opening file for input.\n";
+        return;
+    }
+
+    int intResult;
+    double doubleResult;
+    char charResult;
+    std::string stringResult;
+
+    // Deserialize the data
+    Deserializer::deserialize(inFile, intResult);
+    Deserializer::deserialize(inFile, doubleResult);
+    Deserializer::deserialize(inFile, charResult);
+    Deserializer::deserialize(inFile, stringResult);
+
+    inFile.close();
+
+    std::cout << "Test Int: " << intResult << "\n";
+    std::cout << "Test Double: " << doubleResult << "\n";
+    std::cout << "Test Char: " << charResult << "\n";
+    std::cout << "Test String: " << stringResult << "\n";
+}

--- a/others/serialization.cpp
+++ b/others/serialization.cpp
@@ -31,10 +31,10 @@
 #include <string>       // for std::string
 #include <type_traits>  // for std::is_fundamental
 
-/** \namespace ciphers
- * \brief Classes for binary Serialization and Deserialization 
+/** @namespace serialization
+ * @brief Classes for binary Serialization and Deserialization 
  */
-namespace Serialization {
+namespace serialization {
 /**
  * @class Serializer
  * @brief A utility class for serializing fundamental data types and strings to
@@ -151,10 +151,10 @@ void tests() {
     std::string testString = "Testing String Serialization!";
 
     // Serialize the data
-    Serialization::Serializer::serialize(outFile, testInt);
-    Serialization::Serializer::serialize(outFile, testDouble);
-    Serialization::Serializer::serialize(outFile, testChar);
-    Serialization::Serializer::serialize(outFile, testString);
+    serialization::Serializer::serialize(outFile, testInt);
+    serialization::Serializer::serialize(outFile, testDouble);
+    serialization::Serializer::serialize(outFile, testChar);
+    serialization::Serializer::serialize(outFile, testString);
 
     outFile.close();
 
@@ -170,10 +170,10 @@ void tests() {
     std::string stringResult;
 
     // Deserialize the data
-    Serialization::Deserializer::deserialize(inFile, intResult);
-    Serialization::Deserializer::deserialize(inFile, doubleResult);
-    Serialization::Deserializer::deserialize(inFile, charResult);
-    Serialization::Deserializer::deserialize(inFile, stringResult);
+    serialization::Deserializer::deserialize(inFile, intResult);
+    serialization::Deserializer::deserialize(inFile, doubleResult);
+    serialization::Deserializer::deserialize(inFile, charResult);
+    serialization::Deserializer::deserialize(inFile, stringResult);
 
     inFile.close();
 
@@ -190,7 +190,7 @@ void tests() {
         std::ofstream largeOutFile("large_string.bin", std::ios::binary);
         // Create a string larger than 1MB
         std::string largeString(1024 * 1024 + 1, 'A');
-        Serialization::Serializer::serialize(
+        serialization::Serializer::serialize(
             largeOutFile,
             largeString);  // Should throw an error
         largeOutFile.close();
@@ -219,7 +219,7 @@ void tests() {
                                              std::ios::binary);
 
         std::string deserializedString;
-        Serialization::Deserializer::deserialize(
+        serialization::Deserializer::deserialize(
             missingDelimiterInFile,
             deserializedString);  // Should throw an error
         missingDelimiterInFile.close();

--- a/others/serialization.cpp
+++ b/others/serialization.cpp
@@ -1,19 +1,23 @@
-#include <fstream>
-#include <iostream>
-#include <string>
-#include <cassert> 
-
 /**
  * @file
  * @brief A simple Serializer and Deserializer utility for fundamental data
  * types and strings.
  */
+#include <cassert>      // for assert
+#include <cstdint>      // for std::uint32_t
+#include <fstream>      // for std::ifstream std::ofstream
+#include <iostream>     // for std::ios std::cout std::cerr
+#include <string>       // for std::string
+#include <type_traits>  // for std::is_fundamental
 
+/**
+ * @brief A utility class for serializing fundamental data types and strings to
+ * a binary file.
+ */
 class Serializer {
  public:
     /**
-     * @brief Serializes fundamental data types (like int, float, double, etc.)
-     * to a binary file.
+     * @brief Serializes fundamental data types to a binary file.
      * @tparam T The type of the data to be serialized.
      * @param out The output stream (std::ofstream).
      * @param data The data to be serialized.
@@ -22,7 +26,9 @@ class Serializer {
      */
     template <typename T>
     static void serialize(std::ofstream &out, const T &data) {
-        static_assert(std::is_fundamental<T>::value, "Non-fundamental types are not allowed for this function!");
+        static_assert(
+            std::is_fundamental<T>::value,
+            "Non-fundamental types are not allowed for this function!");
         out.write(reinterpret_cast<const char *>(&data), sizeof(T));
     }
 
@@ -43,8 +49,8 @@ class Serializer {
 };
 
 /**
- * @class Deserializer
- * A utility class for deserializing data from a binary file.
+ * A utility class for deserializing fundamental data types and strings to a
+ * binary file
  */
 class Deserializer {
  public:
@@ -93,55 +99,11 @@ class Deserializer {
         }
     }
 };
-
-void runTests();
-
 /**
- * Demonstrates the use of Serializer and Deserializer for fundamental types and
- * strings.
+ * @brief self test implementation
+ * @return void
  */
-int main() {
-    std::ofstream outFile("output.bin", std::ios::binary);
-    std::ifstream inFile("output.bin", std::ios::binary);
-
-    if (!outFile || !inFile) {
-        std::cerr << "Error opening files.\n";
-        return 1;
-    }
-
-    // Data to be serialized.
-    int num = 42;
-    float pi = 3.14159f;
-    std::string message = "Hello, Sharon!";
-
-    Serializer::serialize(outFile, num);
-    Serializer::serialize(outFile, pi);
-    Serializer::serialize(outFile, message);
-    outFile.close();
-
-    int numRead;
-    float piRead;
-    std::string messageRead;
-
-    // Deserialize the data.
-    Deserializer::deserialize(inFile, numRead);
-    Deserializer::deserialize(inFile, piRead);
-    Deserializer::deserialize(inFile, messageRead);
-    inFile.close();
-
-    std::cout << "Deserialized int: " << numRead << "\n";
-    std::cout << "Deserialized float: " << piRead << "\n";
-    std::cout << "Deserialized string: " << messageRead << "\n";
-
-    return 0;
-}
-
-/**
- * @brief A test suite to perform extensive testing on the Serializer and
- * Deserializer.
- */
-
-void runTests() {
+void tests() {
     std::ofstream outFile("test_output.bin", std::ios::binary);
     if (!outFile) {
         std::cerr << "Error opening file for output.\n";
@@ -188,3 +150,14 @@ void runTests() {
 
     std::cout << "All tests passed!\n";
 }
+
+int main() {
+    tests();
+
+    return 0;
+}
+
+/**
+ * @brief A test suite to perform extensive testing on the Serializer and
+ * Deserializer.
+ */

--- a/others/serialization.cpp
+++ b/others/serialization.cpp
@@ -31,6 +31,10 @@
 #include <string>       // for std::string
 #include <type_traits>  // for std::is_fundamental
 
+/** \namespace ciphers
+ * \brief Classes for binary Serialization and Deserialization 
+ */
+namespace Serialization {
 /**
  * @class Serializer
  * @brief A utility class for serializing fundamental data types and strings to
@@ -68,8 +72,7 @@ class Serializer {
         // Check if the string exceeds the size limit of 1MB.
         const std::uint32_t max_size = 1024 * 1024;
         if (length > max_size) {
-            throw std::runtime_error(
-                "String exceeds the maximum size of 1MB.");
+            throw std::runtime_error("String exceeds the maximum size of 1MB.");
         }
 
         serialize(out, length);           // Serialize the length of the string.
@@ -129,6 +132,8 @@ class Deserializer {
         }
     }
 };
+}  // namespace Serialization
+
 /**
  * @brief self test implementation
  * @return void
@@ -146,10 +151,10 @@ void tests() {
     std::string testString = "Testing String Serialization!";
 
     // Serialize the data
-    Serializer::serialize(outFile, testInt);
-    Serializer::serialize(outFile, testDouble);
-    Serializer::serialize(outFile, testChar);
-    Serializer::serialize(outFile, testString);
+    Serialization::Serializer::serialize(outFile, testInt);
+    Serialization::Serializer::serialize(outFile, testDouble);
+    Serialization::Serializer::serialize(outFile, testChar);
+    Serialization::Serializer::serialize(outFile, testString);
 
     outFile.close();
 
@@ -165,10 +170,10 @@ void tests() {
     std::string stringResult;
 
     // Deserialize the data
-    Deserializer::deserialize(inFile, intResult);
-    Deserializer::deserialize(inFile, doubleResult);
-    Deserializer::deserialize(inFile, charResult);
-    Deserializer::deserialize(inFile, stringResult);
+    Serialization::Deserializer::deserialize(inFile, intResult);
+    Serialization::Deserializer::deserialize(inFile, doubleResult);
+    Serialization::Deserializer::deserialize(inFile, charResult);
+    Serialization::Deserializer::deserialize(inFile, stringResult);
 
     inFile.close();
 
@@ -185,7 +190,9 @@ void tests() {
         std::ofstream largeOutFile("large_string.bin", std::ios::binary);
         // Create a string larger than 1MB
         std::string largeString(1024 * 1024 + 1, 'A');
-        Serializer::serialize(largeOutFile, largeString);  // Should throw an error
+        Serialization::Serializer::serialize(
+            largeOutFile,
+            largeString);  // Should throw an error
         largeOutFile.close();
         assert(false);  // If we reach here, the test has failed.
     } catch (const std::runtime_error &e) {
@@ -195,20 +202,26 @@ void tests() {
     }
     // Test for missing delimiter in string serialization
     try {
-        std::ofstream missingDelimiterOutFile("missing_delimiter.bin",std::ios::binary);
+        std::ofstream missingDelimiterOutFile("missing_delimiter.bin",
+                                              std::ios::binary);
 
         std::string incompleteString = "Incomplete string test";
         std::uint32_t length = incompleteString.size();
 
         // Serialize string length and content without the delimiter
-        missingDelimiterOutFile.write(reinterpret_cast<const char *>(&length),sizeof(length));
-        missingDelimiterOutFile.write(incompleteString.c_str(), length);  // No delimiter '|'
+        missingDelimiterOutFile.write(reinterpret_cast<const char *>(&length),
+                                      sizeof(length));
+        missingDelimiterOutFile.write(incompleteString.c_str(),
+                                      length);  // No delimiter '|'
         missingDelimiterOutFile.close();
 
-        std::ifstream missingDelimiterInFile("missing_delimiter.bin",std::ios::binary);
+        std::ifstream missingDelimiterInFile("missing_delimiter.bin",
+                                             std::ios::binary);
 
         std::string deserializedString;
-        Deserializer::deserialize(missingDelimiterInFile,deserializedString);  // Should throw an error
+        Serialization::Deserializer::deserialize(
+            missingDelimiterInFile,
+            deserializedString);  // Should throw an error
         missingDelimiterInFile.close();
 
         assert(false);
@@ -230,6 +243,6 @@ void tests() {
  * @returns 0 on successful exit
  */
 int main() {
-    tests(); // run self test implementations
+    tests();  // run self test implementations
     return 0;
 }


### PR DESCRIPTION
**Pull Request Title:** Add Serializer and Deserializer Classes for Binary Serialization of Primitives and Strings

**Description:**

This pull request introduces a `Serializer` and `Deserializer` class for the serialization and deserialization of fundamental types such as `int`, `double`, `char`, and `std::string` in binary format. The feature supports both serialization of primitive types and strings, ensuring safe handling of binary data.

For primitives like `int`, `float`, and `double`, serialization is straightforward. However, serializing or deserializing `std::string` is more challenging due to its dynamic size and the absence of a delimiter (like null termination in C-style strings), which means we wouldn’t know how much to read or write.

To address this, the following approach is used:

### **Serializing:**
- Writing the size of the string immediately before the string data.
- Adding a delimiter `|` at the end of the string to signify its boundary.

### **Deserializing:**
- Reading the size of the string before reading the actual string data to know how much to read.
- Reading the string until the delimiter `|` is encountered.

**Note:** You can replace `|` with any other delimiter of your choice if needed.

**Checklist:**
- [x] Added a description of the change.
- [x] File name matches [File Name Guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines).
- [x] Added tests and example; tests must pass.
- [x] Added documentation to make the program self-explanatory and educational, following [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html).
- [x] Relevant documentation/comments are changed or added.
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines).
- [x] Searched for previous suggestions before making a new one to avoid duplication.
- [x] I acknowledge that all my contributions will be made under the project's license.

