### PR TITLE
Revert "chore: use annotations instead of in house linter (#2905)"

### DIFF
--- a/.github/workflows/approved-label.yml
+++ b/.github/workflows/approved-label.yml
@@ -5,10 +5,10 @@ jobs:
     name: Add "approved" label when approved
     runs-on: ubuntu-latest
     steps:
-      - name: Add "approved" label when approved
-        uses: abinoda/label-when-approved-action@v1.0.7
-        env:
-          APPROVALS: "1"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ADD_LABEL: "approved"
-          REMOVE_LABEL: ""
+    - name: Add "approved" label when approved
+      uses: pullreminders/label-when-approved-action@master
+      env:
+        APPROVALS: "1"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ADD_LABEL: "approved"
+        REMOVE_LABEL: ""

--- a/.github/workflows/awesome_workflow.yml
+++ b/.github/workflows/awesome_workflow.yml
@@ -1,28 +1,50 @@
 name: Awesome CI Workflow
 on: [push, pull_request]
 permissions:
-  pull-requests: write
   contents: write
-  issues: write
 
 jobs:
   MainSequence:
     name: Code Formatter
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-      issues: write
     steps:
       - uses: actions/checkout@v4
-      - uses: cpp-linter/cpp-linter-action@v2
-        id: linter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          style: "file"
-          tidy-checks: ".clang-tidy"
-          thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+      - name: requirements
+        run: | 
+          sudo apt-get -qq update
+          sudo apt-get -qq install clang-tidy clang-format
+        # checks are passing with less errors when used with this version. 
+        # The default installs v6.0 which did not work out well in my tests
+      - name: Setup Git Specs
+        run: |
+          git config --global user.name github-actions[bot]
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Filename Formatter
+        run: |
+          wget https://raw.githubusercontent.com/TheAlgorithms/scripts/main/filename_formatter.sh
+          chmod +x filename_formatter.sh
+          ./filename_formatter.sh . .cpp,.hpp
+      - name: Get file changes
+        run: |
+          git branch
+          git diff --diff-filter=dr --name-only origin/master > git_diff.txt
+          echo "Files changed-- `cat git_diff.txt`"
+      - name: Configure for static lint checks
+        # compiling first gives clang-tidy access to all the header files and settings used to compile the programs. 
+        # This will check for macros, if any, on linux and not for Windows. But the use of portability checks should 
+        # be able to catch any errors for other platforms.
+        run: cmake -B build -S . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: Lint modified files
+        shell: bash
+        run: python3 scripts/file_linter.py
+      - name: Commit and push changes
+        run: |
+          git diff DIRECTORY.md
+          git commit -am "clang-format and clang-tidy fixes for ${GITHUB_SHA::8}" || true
+          git push origin HEAD:$GITHUB_REF || true
 
   build:
     name: Compile checks
@@ -37,8 +59,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: GCC problem matcher
-        uses: ammaraskar/gcc-problem-matcher@0.3.0
       - run: |
           cmake -B ./build -S .
           cmake --build build --parallel 4


### PR DESCRIPTION
This reverts commit 41653de7183f12d5eab9fc4077125836f42e6c96.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [ ] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [ ] Relevant documentation/comments is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [ ] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
