### PR TITLE
style: remove unused `vector` includes

### DIFF
--- a/backtracking/graph_coloring.cpp
+++ b/backtracking/graph_coloring.cpp
@@ -20,7 +20,6 @@
 
 #include <array>     /// for std::array
 #include <iostream>  /// for IO operations
-#include <vector>    /// for std::vector
 
 /**
  * @namespace backtracking

--- a/data_structures/trie_tree.cpp
+++ b/data_structures/trie_tree.cpp
@@ -12,7 +12,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <vector>
 
 /** \namespace data_structures
  * \brief Data-structure algorithms

--- a/divide_and_conquer/karatsuba_algorithm_for_fast_multiplication.cpp
+++ b/divide_and_conquer/karatsuba_algorithm_for_fast_multiplication.cpp
@@ -15,7 +15,6 @@
 #include <cassert>   /// for assert
 #include <cstring>   /// for string
 #include <iostream>  /// for IO operations
-#include <vector>    /// for std::vector
 
 /**
  * @namespace divide_and_conquer

--- a/graph/breadth_first_search.cpp
+++ b/graph/breadth_first_search.cpp
@@ -52,7 +52,6 @@
 #include <map>
 #include <queue>
 #include <string>
-#include <vector>
 
 /**
  * \namespace graph


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

This PR removes some unused includes of the `vector` header. Such shell script was useful to identify the files needing an update:
```shell
#!/bin/bash

find . -type f \( -name "*.cpp" -o -name "*.hpp" \) | while read -r file; do
    if grep -q '<vector>' "$file" && ! grep -q 'vector<' "$file"; then
        echo "$file"
    fi
done
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Removed unused `vector` includes.