### PR TITLE
Fix: add bounds check to prevent out-of-range access in getMinimum()

### DIFF
--- a/range_queries/sparse_table_range_queries.cpp
+++ b/range_queries/sparse_table_range_queries.cpp
@@ -83,10 +83,19 @@ std::vector<std::vector<T> > buildTable(const std::vector<T>& A,
 template <typename T>
 int getMinimum(int beg, int end, const std::vector<T>& logs,
                const std::vector<std::vector<T> >& table) {
+        if(beg<0||end<<beg||end>=(int)table[0].size()){
+        cout<<"Error:querry range ["<<beg<<","<<end<<"] is invalid."<<endl;
+        return -1;
+                }
     int p = logs[end - beg + 1];
     int pLen = 1 << p;
+    if (p >= (int)table.size() || beg >= (int)table[p].size() || (end - pLen + 1) >= (int)table[p].size()) {
+        std::cerr << "Error: index out of bounds when accessing sparse table." << std::endl;
+        return -1;
+    }
     return std::min(table[p][beg], table[p][end - pLen + 1]);
 }
+
 }  // namespace sparse_table
 }  // namespace range_queries
 


### PR DESCRIPTION
## Description of Change

Fix the out-of-bounds access issue in the getMinimum() function of the sparse table implementation.
Specifically, I added bounds checking on the query indices beg and end to ensure they lie within the valid range of the input array.
If the indices are out of range or invalid, the function returns a safe default value (-1) instead of accessing invalid memory.
This prevents crashes or undefined behavior when queries exceed array boundaries.

## Checklist

- [x] The code builds without errors  
- [x] The fix addresses the issue described  
- [ ] Added or updated tests if applicable  
- [x] Code follows project style guidelines  
- [ ] Documentation/comments updated where necessary  
- [ ] Commit messages are clear and descriptive  
- [x] No duplicated code or unnecessary changes  

## Notes

This fix improves the robustness of the sparse table range minimum query function, preventing potential crashes caused by invalid query indices.

