### PR TITLE
fix: replace suffle by Fisher-Yates for uniform randomness

### DIFF
--- a/sorting/bogo_sort.cpp
+++ b/sorting/bogo_sort.cpp
@@ -34,10 +34,11 @@ namespace sorting {
  * @returns new array with elements shuffled from a given array
  */
 template <typename T, size_t N>
+//Fisher-Yates shuffle
 std::array <T, N> shuffle (std::array <T, N> arr) {
-    for (int i = 0; i < N; i++) {
-        // Swaps i'th  index with random index (less than array size)
-        std::swap(arr[i], arr[std::rand() % N]);
+    for (int i = N-1; i >=0; i--) {
+        // Swaps i'th  index with random index (less or equal than i)
+        std::swap(arr[i], arr[std::rand() % (i+1)]);
     }
     return arr;
 }


### PR DESCRIPTION
#### Description of Change
- Replaced the current bias shuffle by the Fisher-Yates algorithm. This assures uniform randomness 
- 
#### Checklist
- [x] Added description of change
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: Replaced the current shuffle for Fisher-Yates
