### PR TITLE
fix: add bounds check to prevent out-of-range access in sparse table

### DIFF
--- a/range_queries/sparse_table_range_queries.cpp
+++ b/range_queries/sparse_table_range_queries.cpp
@@ -83,10 +83,19 @@ std::vector<std::vector<T> > buildTable(const std::vector<T>& A,
 template <typename T>
 int getMinimum(int beg, int end, const std::vector<T>& logs,
                const std::vector<std::vector<T> >& table) {
+        if(beg<0||end<<beg||end>=(int)table[0].size()){
+        cout<<"Error:querry range ["<<beg<<","<<end<<"] is invalid."<<endl;
+        return -1;
+                }
     int p = logs[end - beg + 1];
     int pLen = 1 << p;
+    if (p >= (int)table.size() || beg >= (int)table[p].size() || (end - pLen + 1) >= (int)table[p].size()) {
+        std::cerr << "Error: index out of bounds when accessing sparse table." << std::endl;
+        return -1;
+    }
     return std::min(table[p][beg], table[p][end - pLen + 1]);
 }
+
 }  // namespace sparse_table
 }  // namespace range_queries
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->Fix the out-of-bounds access in `getMinimum()` function in `sparse_table_range_queries.cpp`.
Added a boundary check to ensure stable behavior for invalid range queries.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [ ] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [ ] Relevant documentation/comments is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
This fix prevents crashes due to out-of-bounds access in RMQ function.
