### PR TITLE
fix: resize `array` to avoid `arrayIndexOutOfBounds`

### DIFF
--- a/search/linear_search.cpp
+++ b/search/linear_search.cpp
@@ -45,7 +45,10 @@ static void tests() {
     assert(LinearSearch(array, size, 1) == 1);
     assert(LinearSearch(array, size, 2) == 2);
 
+    delete[] array;
+
     size = 6;
+    array = new int[size];
     for (int i = 0; i < size; i++) {
         array[i] = i;
     }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

This PR solves the _array index out of bounds_ problem. When `size` changes, the `array` has to be relocated.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Fix _array index out of bounds_ problem in `linear_search.cpp`.