### PR TITLE
fix: use strict inequality to avoid `containerOutOfBounds`

### DIFF
--- a/range_queries/prefix_sum_array.cpp
+++ b/range_queries/prefix_sum_array.cpp
@@ -31,16 +31,18 @@ namespace range_queries {
  */
 namespace prefix_sum_array {
 
-std::vector<int64_t> PSA(1, 0);
+std::vector<int64_t> PSA{};
 
 /**
  * @brief function that builds the PSA
  * @param original_array original array of values
  * @returns void
  */
-void build(std::vector<int64_t> original_array) {
-    for (int i = 1; i <= static_cast<int>(original_array.size()); i++) {
-        PSA.push_back(PSA[i - 1] + original_array[i]);
+void build(const std::vector<int64_t>& original_array) {
+    PSA.clear();
+    PSA.push_back(0);
+    for (std::size_t i = 1; i < original_array.size(); ++i) {
+        PSA.push_back(PSA.back() + original_array[i]);
     }
 }
 /**


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

Observe that in the _old code_, because the `<=` is used in the loop, there is an _index out of bounds_ error. The main reason for this PR is to fix this problem. The rest is just _fix as you go_:
- `std::size_t` should be used for _indexing_ standard containers,
- the api is slightly more intuitive now (consider calling the `build` function twice in the old code). 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Fix _one-off_ error leading to _index out of bounds_.