### PR TITLE
Added constexpr GRAVITY constant (9.80665) as per guidelines

### DIFF
--- a/physics/ground_to_ground_projectile_motion.cpp
+++ b/physics/ground_to_ground_projectile_motion.cpp
@@ -20,7 +20,7 @@
  */
 
 // Define gravity as a constant within guidelines
-constexpr double GRAVITY = 9.80665; // Standard gravity (m/s^2)
+constexpr double GRAVITY = 9.80665; ///< Standard gravity (m/s^2)
 
 
 namespace physics {

--- a/physics/ground_to_ground_projectile_motion.cpp
+++ b/physics/ground_to_ground_projectile_motion.cpp
@@ -18,6 +18,11 @@
  * @namespace physics
  * @brief Physics algorithms
  */
+
+// Define gravity as a constant within guidelines
+constexpr double GRAVITY = 9.80665; // Standard gravity (m/s^2)
+
+
 namespace physics {
 /**
  * @namespace ground_to_ground_projectile_motion
@@ -44,7 +49,7 @@ double degrees_to_radians(double degrees){
  * @returns The time that the projectile is in the air for
  */
 template <typename T>
-T time_of_flight(T initial_velocity, T angle, double gravity = 9.81) {
+T time_of_flight(T initial_velocity, T angle, double gravity = GRAVITY) {
     double Viy = initial_velocity * (std::sin(degrees_to_radians(angle))); // calculate y component of the initial velocity
     return 2.0 * Viy / gravity;
 }
@@ -69,7 +74,7 @@ T horizontal_range(T initial_velocity, T angle, T time) {
  * @returns The max height that the projectile reaches
  */
 template <typename T>
-T max_height(T initial_velocity, T angle, double gravity = 9.81) {
+T max_height(T initial_velocity, T angle, double gravity = GRAVITY) {
     double Viy = initial_velocity * (std::sin(degrees_to_radians(angle))); // calculate y component of the initial velocity
     return (std::pow(Viy, 2) / (2.0 * gravity));
 }


### PR DESCRIPTION
#### Description of Change
<!--
Added constexpr double GRAVITY = 9.80665; as a standard gravity constant in physics algorithms to replace hardcoded values. This improves code readability, consistency, and follows international standards.
-->

#### Checklist

- [x] Added description of change
- [x] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: Introduced GRAVITY constant (9.80665 m/s²) for consistent use across physics algorithms.
