### PR TITLE
fix: initialise `key` to avoid undefined behaviour

### DIFF
--- a/search/hash_search.cpp
+++ b/search/hash_search.cpp
@@ -98,7 +98,7 @@ int hash_search(int key, int* counter) {  // Hash lookup function
 /** main function */
 int main() {
     link p;
-    int key, index, i, counter;  // Key is the value to be found
+    int key = 0, index, i, counter;  // Key is the value to be found
     index = 0;
 
     // You can write the input mode here


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

`key` has to be initialized before readings its value in the `while` loop below.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Initialise `key` to avoid UB.