### PR TITLE
fix: add permissions for Approved label CI (#2719)

### DIFF
--- a/.github/workflows/approved-label.yml
+++ b/.github/workflows/approved-label.yml
@@ -1,14 +1,16 @@
 on: pull_request_review
 name: Add "approved" label when approved
+permissions:
+  pull-requests: write
 jobs:
   add_label:
     name: Add "approved" label when approved
     runs-on: ubuntu-latest
     steps:
-    - name: Add "approved" label when approved
-      uses: pullreminders/label-when-approved-action@master
-      env:
-        APPROVALS: "1"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ADD_LABEL: "approved"
-        REMOVE_LABEL: ""
+      - name: Add "approved" label when approved
+        uses: pullreminders/label-when-approved-action@master
+        env:
+          APPROVALS: "1"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ADD_LABEL: "approved"
+          REMOVE_LABEL: ""


### PR DESCRIPTION
#### Description of Change
Added `pull-requests: write` permission to the `approved-label.yml` workflow.  
This fixes issue #2719 where the Approved Label CI could not add the "approved" label to PRs due to insufficient permissions (403 error).  

#### Checklist
- [x] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)  
- [ ] Added tests and example, test must pass  
- [ ] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)  
- [x] Relevant documentation/comments is changed or added  
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)  
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.  
- [x] I acknowledge that all my contributions will be made under the project's license.  

Notes:  
This PR fixes #2719 by updating the workflow permissions.
