### PR TITLE
refactor: input size should not be a template argument in `postfix_evaluation`

### DIFF
--- a/others/postfix_evaluation.cpp
+++ b/others/postfix_evaluation.cpp
@@ -12,11 +12,11 @@
  * When the expression is ended, the number in the stack is the final answer
  */
 #include <algorithm>  // for all_of
-#include <array>      // for array
 #include <cassert>    // for assert
 #include <iostream>   // for io operations
 #include <stack>      // for std::stack
 #include <string>     // for stof
+#include <vector>     // for std::vector
 
 /**
  * @namespace others
@@ -80,17 +80,13 @@ void evaluate(float a, float b, const std::string &operation,
 /**
  * @brief Postfix Evaluation algorithm to compute the value from given input
  * array
- * @tparam N number of array size
- * @param input Array of characters consisting of numbers and operations
+ * @param input vector of strings consisting of numbers and operations
  * @returns stack[stackTop] returns the top value from the stack
  */
-template <std::size_t N>
-float postfix_evaluation(std::array<std::string, N> input) {
+float postfix_evaluation(const std::vector<std::string> &input) {
     std::stack<float> stack;
-    int j = 0;
 
-    while (j < N) {
-        std::string scan = input[j];
+    for (const auto &scan : input) {
         if (is_number(scan)) {
             stack.push(std::stof(scan));
 
@@ -102,7 +98,6 @@ float postfix_evaluation(std::array<std::string, N> input) {
 
             evaluate(op1, op2, scan, stack);
         }
-        j++;
     }
 
     std::cout << stack.top() << "\n";
@@ -118,7 +113,7 @@ float postfix_evaluation(std::array<std::string, N> input) {
  * @returns none
  */
 static void test_function_1() {
-    std::array<std::string, 7> input = {"2", "3", "1", "*", "+", "9", "-"};
+    std::vector<std::string> input = {"2", "3", "1", "*", "+", "9", "-"};
 
     float answer = others::postfix_expression::postfix_evaluation(input);
 
@@ -131,15 +126,15 @@ static void test_function_1() {
  * @returns none
  */
 static void test_function_2() {
-    std::array<std::string, 9> input = {"100", "200", "+", "2", "/",
-                                        "5",   "*",   "7", "+"};
+    std::vector<std::string> input = {"100", "200", "+", "2", "/",
+                                      "5",   "*",   "7", "+"};
     float answer = others::postfix_expression::postfix_evaluation(input);
 
     assert(answer == 757);
 }
 
 static void test_function_3() {
-    std::array<std::string, 43> input = {
+    std::vector<std::string> input = {
         "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1",
         "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1",
         "+", "+", "+", "+", "+", "+", "+", "+", "+", "+", "+",


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

Since the input size of [`postfix_evaluation`](https://github.com/vil02/C-Plus-Plus/blob/3aafade824d9f615fcf63b3f22fe8d6f7652fec0/others/postfix_evaluation.cpp#L88) is a template parameter, this function needs to be compile for every used input size (this increases both the build time and the size of the binary).

This PR changes the the type of the input to `std::vector` to avoid such problem.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [x] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Use `std::vector` as input type, to avoid increase of build time and binary size.