### PR TITLE
Fix: Add permission for approved-label workflow to label pull requests

### DIFF
--- a/.github/workflows/approved-label.yml
+++ b/.github/workflows/approved-label.yml
@@ -12,3 +12,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ADD_LABEL: "approved"
         REMOVE_LABEL: ""
+permissions:
+  pull_request: write


### PR DESCRIPTION
#### Description of Change
Fixes #2719.

Added `pull_request: write` permission to the `.github/workflows/approved-label.yml` workflow file.  
This change ensures the CI workflow can successfully add the "approved" label to pull requests, as described in the issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: Added the required permission to allow the workflow to add labels to pull requests, resolving the problem in #2719.