### PR TITLE
Fix: use uint64_t for input and counter in countSetBits

### DIFF
--- a/bit_manipulation/count_of_set_bits.cpp
+++ b/bit_manipulation/count_of_set_bits.cpp
@@ -36,11 +36,19 @@ namespace count_of_set_bits {
  * @returns total number of set-bits in the binary representation of number `n`
  */
 std::uint64_t countSetBits(
-    std ::int64_t n) {  // int64_t is preferred over int so that
+    std ::uint64_t n) {  // uint64_t is preferred over int so that
                         // no Overflow can be there.
+                        //It's preferred over int64_t because it Guarantees that inputs are always non-negative, 
+                        //which matches the algorithmic problem statement.
+                        //set bit counting is conceptually defined only for non-negative numbers.
+                        //Provides a type Safety: Using an unsigned type helps prevent accidental negative values,
 
-    int count = 0;  // "count" variable is used to count number of set-bits('1')
-                    // in binary representation of number 'n'
+    std::uint64_t count = 0;  // "count" variable is used to count number of set-bits('1')
+                            // in binary representation of number 'n'
+                            //Count is uint64_t because it Prevents theoretical overflow if someone passes very large integers.
+                            //  Behavior stays the same for all normal inputs.
+                            // Safer for edge cases.
+
     while (n != 0) {
         ++count;
         n = (n & (n - 1));


### PR DESCRIPTION
#### Description of Change
Updated the `countSetBits` function in bit_manipulation/count_of_set_bits.cpp to improve **type safety and correctness**:  
- Changed the input parameter from `int64_t` to `uint64_t` to ensure only non-negative numbers are allowed.  
- Changed the internal counter variable `count` from `int` to `uint64_t` to match the return type and prevent any theoretical overflow.  
- Maintains original functionality for normal inputs.

This ensures the function is consistent, safe, and fully aligned with the intended use of counting set bits in non-negative integers.

---
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

#### Checklist
- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [x] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

---

**Notes:**  
Improves type safety for `countSetBits` function without changing its behavior for normal inputs.