### PR TITLE
fix: handle wrong inputs in `postfix_evaluation`

### DIFF
--- a/others/postfix_evaluation.cpp
+++ b/others/postfix_evaluation.cpp
@@ -77,6 +77,17 @@ void evaluate(float a, float b, const std::string &operation,
     }
 }
 
+namespace {
+float remove_from_stack(std::stack<float> &stack) {
+    if (stack.empty()) {
+        throw std::invalid_argument("Not enough operands");
+    }
+    const auto res = stack.top();
+    stack.pop();
+    return res;
+}
+}  // namespace
+
 /**
  * @brief Postfix Evaluation algorithm to compute the value from given input
  * array
@@ -91,18 +102,18 @@ float postfix_evaluation(const std::vector<std::string> &input) {
             stack.push(std::stof(scan));
 
         } else {
-            const float op2 = stack.top();
-            stack.pop();
-            const float op1 = stack.top();
-            stack.pop();
+            const auto op2 = remove_from_stack(stack);
+            const auto op1 = remove_from_stack(stack);
 
             evaluate(op1, op2, scan, stack);
         }
     }
 
-    std::cout << stack.top() << "\n";
-
-    return stack.top();
+    const auto res = remove_from_stack(stack);
+    if (!stack.empty()) {
+        throw std::invalid_argument("Too many operands");
+    }
+    return res;
 }
 }  // namespace postfix_expression
 }  // namespace others
@@ -144,6 +155,46 @@ static void test_function_3() {
     assert(answer == 22);
 }
 
+static void test_single_input() {
+    std::vector<std::string> input = {"1"};
+    float answer = others::postfix_expression::postfix_evaluation(input);
+
+    assert(answer == 1);
+}
+
+static void test_not_enough_operands() {
+    std::vector<std::string> input = {"+"};
+    bool throws = false;
+    try {
+        others::postfix_expression::postfix_evaluation(input);
+    } catch (std::invalid_argument &) {
+        throws = true;
+    }
+    assert(throws);
+}
+
+static void test_not_enough_operands_empty_input() {
+    std::vector<std::string> input = {};
+    bool throws = false;
+    try {
+        others::postfix_expression::postfix_evaluation(input);
+    } catch (std::invalid_argument &) {
+        throws = true;
+    }
+    assert(throws);
+}
+
+static void test_too_many_operands() {
+    std::vector<std::string> input = {"1", "2"};
+    bool throws = false;
+    try {
+        others::postfix_expression::postfix_evaluation(input);
+    } catch (std::invalid_argument &) {
+        throws = true;
+    }
+    assert(throws);
+}
+
 /**
  * @brief Main function
  * @returns 0 on exit
@@ -152,6 +203,10 @@ int main() {
     test_function_1();
     test_function_2();
     test_function_3();
+    test_single_input();
+    test_not_enough_operands();
+    test_not_enough_operands_empty_input();
+    test_too_many_operands();
 
     std::cout << "\nTest implementations passed!\n";
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md
-->

The previous version of the code did not handle properly the incorrect inputs potentially leasing to segmentation faults. This change updates the code to handle all possible cases. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [x] Added tests and example, test must pass
- [x] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Handle incorrect inputs in \`postfix_evaluation\`.