### PR TITLE
chore: fix file formatter

### DIFF
--- a/scripts/file_linter.py
+++ b/scripts/file_linter.py
@@ -12,43 +12,38 @@ with open("git_diff.txt") as in_file:
     print(f"{len(cpp_files)} C++ files were modified.")
     if not cpp_files:
         sys.exit(0)
-    else:
-        subprocess.run(
-            [
-                "clang-tidy",
-                "--fix",
-                "-p=build",
-                "--extra-arg=-std=c++11",
-                *cpp_files,
-                "--",
-            ],
-            check=True,
-            text=True,
-            stderr=subprocess.STDOUT,
-        )
 
-        subprocess.run(
-            ["clang-format", "-i", "-style=file", *cpp_files],
-            check=True,
-            text=True,
-            stderr=subprocess.STDOUT,
-        )
-
-        upper_files = [file for file in cpp_files if file != file.lower()]
-        if upper_files:
-            print(f"{len(upper_files)} files contain uppercase characters:")
-            print("\n".join(upper_files) + "\n")
-
-        space_files = [file for file in cpp_files if " " in file or "-" in file]
-        if space_files:
-            print(f"{len(space_files)} files contain space or dash characters:")
-            print("\n".join(space_files) + "\n")
-
-        nodir_files = [file for file in cpp_files if file.count(os.sep) != 1]
-        if nodir_files:
-            print(f"{len(nodir_files)} files are not in one and only one directory:")
-            print("\n".join(nodir_files) + "\n")
-
-        bad_files = len(upper_files + space_files + nodir_files)
-        if bad_files:
-            sys.exit(bad_files)
+    subprocess.run(
+        [
+            "clang-tidy",
+            "--fix",
+            "-p=build",
+            "--extra-arg=-std=c++11",
+            *cpp_files,
+            "--",
+        ],
+        check=True,
+        text=True,
+        stderr=subprocess.STDOUT,
+    )
+    subprocess.run(
+        ["clang-format", "-i", "-style=file", *cpp_files],
+        check=True,
+        text=True,
+        stderr=subprocess.STDOUT,
+    )
+    upper_files = [file for file in cpp_files if file != file.lower()]
+    if upper_files:
+        print(f"{len(upper_files)} files contain uppercase characters:")
+        print("\n".join(upper_files) + "\n")
+    space_files = [file for file in cpp_files if " " in file or "-" in file]
+    if space_files:
+        print(f"{len(space_files)} files contain space or dash characters:")
+        print("\n".join(space_files) + "\n")
+    nodir_files = [file for file in cpp_files if file.count(os.sep) != 1]
+    if nodir_files:
+        print(f"{len(nodir_files)} files are not in one and only one directory:")
+        print("\n".join(nodir_files) + "\n")
+    bad_files = len(upper_files + space_files + nodir_files)
+    if bad_files:
+        sys.exit(bad_files)

--- a/scripts/file_linter.py
+++ b/scripts/file_linter.py
@@ -6,18 +6,33 @@ print("Python {}.{}.{}".format(*sys.version_info))  # Python 3.8
 with open("git_diff.txt") as in_file:
     modified_files = sorted(in_file.read().splitlines())
     print("{} files were modified.".format(len(modified_files)))
-    
+
     cpp_exts = tuple(".c .c++ .cc .cpp .cu .cuh .cxx .h .h++ .hh .hpp .hxx".split())
     cpp_files = [file for file in modified_files if file.lower().endswith(cpp_exts)]
     print(f"{len(cpp_files)} C++ files were modified.")
     if not cpp_files:
         sys.exit(0)
+    else:
+        subprocess.run(
+            [
+                "clang-tidy",
+                "--fix",
+                "-p=build",
+                "--extra-arg=-std=c++11",
+                *cpp_files,
+                "--",
+            ],
+            check=True,
+            text=True,
+            stderr=subprocess.STDOUT,
+        )
 
-        subprocess.run(["clang-tidy", "--fix", "-p=build", "--extra-arg=-std=c++11", *cpp_files, "--"], 
-            check=True, text=True, stderr=subprocess.STDOUT)
-
-        subprocess.run(["clang-format", "-i", "-style=file", *cpp_files], 
-            check=True, text=True, stderr=subprocess.STDOUT)
+        subprocess.run(
+            ["clang-format", "-i", "-style=file", *cpp_files],
+            check=True,
+            text=True,
+            stderr=subprocess.STDOUT,
+        )
 
         upper_files = [file for file in cpp_files if file != file.lower()]
         if upper_files:


### PR DESCRIPTION
#### Description of Change

## fault
File formatter always exits early becuase of unreachable code, Intially while copying this script from the workflow file(#2500) the indentation was not proper

## fix
removed the unneccessary indentation

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
