### PR TITLE
ci: use a different action for approved-label workflow

### DIFF
--- a/.github/workflows/approved-label.yml
+++ b/.github/workflows/approved-label.yml
@@ -5,10 +5,9 @@ jobs:
     name: Add "approved" label when approved
     runs-on: ubuntu-latest
     steps:
-    - name: Add "approved" label when approved
-      uses: pullreminders/label-when-approved-action@master
-      env:
-        APPROVALS: "1"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ADD_LABEL: "approved"
-        REMOVE_LABEL: ""
+      - name: Add "approved" label when approved
+        uses: realstealthninja/label-when-approved@main
+        with:
+          approvals: 1
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          label: "approved"


### PR DESCRIPTION
#### Description of Change
Recently the label on approved action has been deleted, For a long time now it has not been working properly and now has started openly failing. 
This PR fixes the issue by creating the same action using modern JavaScript and action toolkit. 
uses [label as approved](https://www.github.com/realstealthninja/label-when-approved).
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: fixes #2719 