### PR TITLE
Fix Fibonacci calculation to return fib(0) as 0

### DIFF
--- a/dynamic_programming/fibonacci_bottom_up.cpp
+++ b/dynamic_programming/fibonacci_bottom_up.cpp
@@ -9,7 +9,7 @@ int fib(int n) {
         res[0] = res[1];
         res[1] = res[2];
     }
-    return res[1];
+    return res[0]; // actual fibonnaci seequence for fib(0) is 0 (zero)
 }
 int main() {
     int n;


### PR DESCRIPTION
Fix return value to correctly return fib(0) as 0.

#### Description of Change
<!--
The change is intended to make sure that the program outputs the value of "zero" when the fib() function is parameterized with integer zero
-->

#### Checklist

- [x] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [ ] Added documentation so that the program is self-explanatory and educational - [Doxygen guidelines](https://www.doxygen.nl/manual/docblocks.html)
- [ ] Relevant documentation/comments is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [ ] I acknowledge that all my contributions will be made under the project's license.

Notes: The program file dynamic_programming/fibonacci_bottom_up.cpp is intended to return the fibonacci sequence of the number entered